### PR TITLE
CI: fix workflow startup_failure (matrix context in shell:)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,11 +50,28 @@ jobs:
           Import-Module Pester -MinimumVersion 5.0.0
           (Get-Module Pester).Version
 
-      - name: Run Pester tests
-        shell: ${{ matrix.shell }}
+      # NOTE: do NOT collapse these two steps into one with `shell: ${{ matrix.shell }}`.
+      # The `matrix` context is not available in a step's `shell:` key, so GitHub
+      # rejects it at workflow-parse time -- a startup_failure that kills the ENTIRE
+      # workflow (no jobs run, both legs show red). `matrix` IS allowed in `if:`, so
+      # branch on the shell there instead.
+      - name: Run Pester tests (pwsh 7)
+        if: matrix.shell == 'pwsh'
+        shell: pwsh
         run: |
           # Pin to Pester 5 explicitly so WinPS 5.1 doesn't auto-load its in-box
           # Pester 3 (which lacks New-PesterConfiguration).
+          Import-Module Pester -MinimumVersion 5.0.0
+          $config = New-PesterConfiguration
+          $config.Run.Path = 'tests'
+          $config.Run.Exit = $true
+          $config.Output.Verbosity = 'Detailed'
+          Invoke-Pester -Configuration $config
+
+      - name: Run Pester tests (Windows PowerShell 5.1)
+        if: matrix.shell == 'powershell'
+        shell: powershell
+        run: |
           Import-Module Pester -MinimumVersion 5.0.0
           $config = New-PesterConfiguration
           $config.Run.Path = 'tests'


### PR DESCRIPTION
## Problem

CI has failed on **every** push since `b1758f4d` ("add Windows PowerShell 5.1 test leg"). Every run was a **`startup_failure`**: zero jobs, zero logs, both matrix legs red — and runs even fired on non-`main` branches, because GitHub couldn't parse the workflow far enough to apply the branch filter.

## Root cause

```yaml
- name: Run Pester tests
  shell: ${{ matrix.shell }}   # <-- invalid
```

The `matrix` context is **not available** in a step's `shell:` key, so GitHub rejects the workflow at parse time — killing the entire run before any job starts. (`actionlint` flags exactly this line.) The tests themselves were never broken; they pass on both pwsh 7 and WinPS 5.1.

## Fix

Select the shell with two `if`-guarded run steps (`matrix` **is** allowed in `if:`).

## Verification

- `actionlint` clean (exit 0) on the fixed file.
- Full Pester suite passes locally on **both** pwsh 7 and Windows PowerShell 5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)