### PR TITLE
feat(macos): run on macOS/Linux terminals, not just Windows Terminal

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -13,23 +13,67 @@
 
 #Requires -Version 5.1
 
+function Get-TStylesPlatform {
+    # NOTE: duplicated from tstyles.ps1 -- keep in sync. (install.ps1 is the
+    # bootstrap entry point, fetched and piped to iex before the module exists,
+    # so it cannot dot-source the library.)
+    if ($PSVersionTable.PSVersion.Major -lt 6) { return 'Windows' }
+    if ($IsWindows) { return 'Windows' }
+    if ($IsMacOS)   { return 'MacOS' }
+    return 'Linux'
+}
+
+function Get-TStylesDataRoot {
+    # NOTE: duplicated from tstyles.ps1 -- keep in sync.
+    param(
+        [string]$Platform = (Get-TStylesPlatform),
+        [string]$HomeDir  = $HOME
+    )
+    switch ($Platform) {
+        'Windows' {
+            $base = $env:LOCALAPPDATA
+            if (-not $base) { $base = Join-Path $HomeDir 'AppData\Local' }
+            return Join-Path $base 'TerminalStyles'
+        }
+        'MacOS' {
+            return Join-Path (Join-Path $HomeDir 'Library/Application Support') 'TerminalStyles'
+        }
+        default {
+            $base = $env:XDG_DATA_HOME
+            if (-not $base) { $base = Join-Path (Join-Path $HomeDir '.local') 'share' }
+            return Join-Path $base 'TerminalStyles'
+        }
+    }
+}
+
 $repo       = 'fcreme/TerminalStyles'
 $branch     = 'main'
-$installDir = Join-Path $env:LOCALAPPDATA 'TerminalStyles'
+$installDir = Get-TStylesDataRoot
 $zipUrl     = "https://github.com/$repo/archive/refs/heads/$branch.zip"
 # GUID-suffix both temp paths so back-to-back runs (or a crashed prior
 # run leaving a locked file behind) never collide. AV scanners and
-# OneDrive sync can hold transient locks on $env:TEMP files; a fresh
+# OneDrive sync can hold transient locks on temp files; a fresh
 # name per invocation sidesteps that entirely.
+# GetTempPath(), not $env:TEMP: the var is Windows-only -- on macOS/Linux it is
+# unset, and Join-Path would throw on a null path before the installer ran.
 $runId      = [guid]::NewGuid().Guid.Substring(0,8)
-$tempZip    = Join-Path $env:TEMP "TerminalStyles-$branch-$runId.zip"
-$tempDir    = Join-Path $env:TEMP "TerminalStyles-extract-$runId"
+$tempRoot   = [System.IO.Path]::GetTempPath()
+$tempZip    = Join-Path $tempRoot "TerminalStyles-$branch-$runId.zip"
+$tempDir    = Join-Path $tempRoot "TerminalStyles-extract-$runId"
 
 $loaderBegin = '# ===== TerminalStyles BEGIN ====='
 $loaderEnd   = '# ===== TerminalStyles END ====='
+# Windows keeps the %LOCALAPPDATA%-relative form it has always written, so
+# existing profiles see no diff on reinstall. Elsewhere there is no equivalent
+# env var, so bake in the resolved absolute path.
+$loaderImport = if ((Get-TStylesPlatform) -eq 'Windows') {
+    'Import-Module "$env:LOCALAPPDATA\TerminalStyles\TerminalStyles.psd1" -DisableNameChecking'
+} else {
+    'Import-Module "{0}" -DisableNameChecking' -f (Join-Path $installDir 'TerminalStyles.psd1')
+}
 $loaderBody  = @"
 $loaderBegin
-Import-Module "`$env:LOCALAPPDATA\TerminalStyles\TerminalStyles.psd1" -DisableNameChecking
+$loaderImport
 $loaderEnd
 "@
 

--- a/terminals.ps1
+++ b/terminals.ps1
@@ -1,0 +1,323 @@
+# terminals.ps1 -- terminal backend detection and capability model.
+#
+# TerminalStyles began as a Windows Terminal tool: a style was applied by
+# merging theme.json into WT's settings.json. Every other terminal describes
+# itself differently (iTerm2 has Dynamic Profile JSON, Terminal.app has
+# NSKeyedArchiver plists, the rest have plain-text configs), and none of them
+# support the full WT field set. This file is the seam between "what a style
+# asks for" and "what the host terminal can actually do".
+#
+# Two orthogonal axes:
+#
+#   Detection   -- which terminal is hosting THIS session (Get-TerminalKind).
+#   Capability  -- which style fields that terminal can honour
+#                  (Get-TerminalCapability), so callers degrade gracefully
+#                  instead of writing settings nothing will read.
+#
+# Dot-sourced by tstyles.ps1. Kept separate because the WT-specific merge logic
+# in tstyles.ps1 is already long, and because the adapters are the part most
+# likely to grow (one block per terminal).
+
+# Every capability a style can ask for. A terminal's capability record is a
+# hashtable over exactly these keys, so a typo surfaces as a missing key rather
+# than a silently-false feature test.
+$script:TStylesCapabilityNames = @(
+    'OscPalette',      # OSC 4/10/11/12 dynamic colors -- live retint, no config write
+    'Persist',         # can we write a config that survives a new tab/window?
+    'Font',            # font family + size
+    'Opacity',         # window transparency
+    'CursorShape',     # block / bar / underscore / filled
+    'BackgroundImage', # a wallpaper behind the text
+    'TabTitle',        # per-profile tab title
+    'TabColor',        # per-profile tab accent color
+    'Padding'          # interior window padding
+)
+
+function Get-TerminalKind {
+    # Identify the terminal emulator hosting this session.
+    #
+    # Detection is env-var based and ordered most-specific first, because the
+    # generic markers overlap: WezTerm and iTerm2 both set TERM_PROGRAM, and a
+    # multiplexer or SSH session can inherit a stale value from wherever it was
+    # launched. Returns 'Unknown' rather than guessing -- callers fall back to
+    # the OSC path, which is the one thing that works nearly everywhere.
+    #
+    # -EnvTable is a test seam: a hashtable standing in for $env:. Real callers
+    # omit it and the live environment is read.
+    param([hashtable]$EnvTable)
+
+    $get = {
+        param([string]$Name)
+        if ($null -ne $EnvTable) { return $EnvTable[$Name] }
+        return [System.Environment]::GetEnvironmentVariable($Name)
+    }
+
+    # Windows Terminal sets WT_SESSION on every tab it hosts. Checked first
+    # because WT also runs on the same machine as VS Code's terminal, which
+    # would otherwise match on TERM_PROGRAM below.
+    if (& $get 'WT_SESSION') { return 'WindowsTerminal' }
+
+    # kitty and Alacritty set no TERM_PROGRAM, only their own markers.
+    if (& $get 'KITTY_WINDOW_ID')    { return 'Kitty' }
+    if (& $get 'ALACRITTY_WINDOW_ID'){ return 'Alacritty' }
+    if (& $get 'GHOSTTY_RESOURCES_DIR') { return 'Ghostty' }
+
+    # ITERM_SESSION_ID is set even when TERM_PROGRAM has been clobbered by a
+    # multiplexer, so it is the more reliable iTerm2 signal of the two.
+    if (& $get 'ITERM_SESSION_ID')   { return 'ITerm2' }
+
+    switch ((& $get 'TERM_PROGRAM')) {
+        'Apple_Terminal' { return 'AppleTerminal' }
+        'iTerm.app'      { return 'ITerm2' }
+        'WezTerm'        { return 'WezTerm' }
+        'ghostty'        { return 'Ghostty' }
+        'vscode'         { return 'VSCode' }
+    }
+
+    return 'Unknown'
+}
+
+function Get-TerminalCapability {
+    # The capability record for a terminal kind: a hashtable keyed by
+    # $script:TStylesCapabilityNames, every value a [bool].
+    #
+    # These are deliberately conservative. A capability marked $false means
+    # "TerminalStyles will not try", which degrades to a plainer theme; marking
+    # something $true that the terminal ignores is worse, because the user is
+    # told a setting was applied and sees nothing change.
+    param([string]$Kind = (Get-TerminalKind))
+
+    # Baseline: nothing. Each block below turns on only what it can prove.
+    $caps = @{}
+    foreach ($n in $script:TStylesCapabilityNames) { $caps[$n] = $false }
+
+    switch ($Kind) {
+        'WindowsTerminal' {
+            # The original target, and still the only one that honours the whole
+            # theme.json field set.
+            foreach ($n in $script:TStylesCapabilityNames) { $caps[$n] = $true }
+        }
+        'ITerm2' {
+            # Dynamic Profiles: a JSON file dropped in DynamicProfiles/ is picked
+            # up live, no restart. Covers everything except WT's tab styling.
+            $caps.OscPalette      = $true
+            $caps.Persist         = $true
+            $caps.Font            = $true
+            $caps.Opacity         = $true
+            $caps.CursorShape     = $true
+            $caps.BackgroundImage = $true
+            $caps.TabTitle        = $true
+            $caps.Padding         = $true
+        }
+        'AppleTerminal' {
+            # Persistence goes through a .terminal profile plist. Terminal.app
+            # has no background-image support at all, and no per-profile tab
+            # accent color.
+            #
+            # OscPalette is $true on the strength of a round-trip probe against
+            # Terminal.app 470 (macOS 26): OSC 4/10/11/12 all answered their
+            # query form, setting OSC 11 to #ff00ff read back as ff00/0000/ff00,
+            # and OSC 111 / OSC 104 restored the profile defaults exactly. So the
+            # picker's live preview and its Esc revert both work here with the
+            # same escape packets Windows Terminal uses -- no AppleScript needed
+            # on the hot path.
+            $caps.OscPalette  = $true
+            $caps.Persist     = $true
+            $caps.Font        = $true
+            $caps.Opacity     = $true
+            $caps.CursorShape = $true
+            $caps.TabTitle    = $true
+        }
+        'Ghostty' {
+            $caps.OscPalette  = $true
+            $caps.Persist     = $true
+            $caps.Font        = $true
+            $caps.Opacity     = $true
+            $caps.CursorShape = $true
+            $caps.Padding     = $true
+        }
+        'WezTerm' {
+            $caps.OscPalette      = $true
+            $caps.Persist         = $true
+            $caps.Font            = $true
+            $caps.Opacity         = $true
+            $caps.CursorShape     = $true
+            $caps.BackgroundImage = $true
+            $caps.Padding         = $true
+        }
+        'Kitty' {
+            $caps.OscPalette  = $true
+            $caps.Persist     = $true
+            $caps.Font        = $true
+            $caps.Opacity     = $true
+            $caps.CursorShape = $true
+            $caps.Padding     = $true
+        }
+        'Alacritty' {
+            $caps.OscPalette  = $true
+            $caps.Persist     = $true
+            $caps.Font        = $true
+            $caps.Opacity     = $true
+            $caps.CursorShape = $true
+            $caps.Padding     = $true
+        }
+        'VSCode' {
+            # The integrated terminal honours OSC colors for the session but its
+            # settings live in VS Code's own settings.json, which is not ours to
+            # rewrite. Live-only.
+            $caps.OscPalette = $true
+        }
+        default {
+            # Unknown terminal: assume only the lowest common denominator. Nearly
+            # every emulator written in the last two decades handles OSC 4/10/11,
+            # and getting it wrong costs one stray escape sequence, not a
+            # corrupted config file.
+            $caps.OscPalette = $true
+        }
+    }
+
+    return $caps
+}
+
+function Test-TerminalCapability {
+    # Convenience predicate: does $Kind support $Capability?
+    # Throws on an unknown capability name so a typo fails loudly at the call
+    # site instead of quietly reading as "unsupported".
+    param(
+        [Parameter(Mandatory)][string]$Capability,
+        [string]$Kind = (Get-TerminalKind)
+    )
+    if ($script:TStylesCapabilityNames -notcontains $Capability) {
+        throw "Unknown terminal capability '$Capability'. Known: $($script:TStylesCapabilityNames -join ', ')"
+    }
+    return [bool](Get-TerminalCapability -Kind $Kind)[$Capability]
+}
+
+function Get-TerminalDisplayName {
+    # Human-readable name for messages ("Ghostty", not "Ghostty" == kind by
+    # accident). Kept as an explicit map so renaming a kind doesn't silently
+    # change user-facing output.
+    param([string]$Kind = (Get-TerminalKind))
+    switch ($Kind) {
+        'WindowsTerminal' { 'Windows Terminal' }
+        'AppleTerminal'   { 'Terminal.app' }
+        'ITerm2'          { 'iTerm2' }
+        'Ghostty'         { 'Ghostty' }
+        'WezTerm'         { 'WezTerm' }
+        'Kitty'           { 'kitty' }
+        'Alacritty'       { 'Alacritty' }
+        'VSCode'          { 'VS Code terminal' }
+        default           { 'this terminal' }
+    }
+}
+
+function Test-StyledHost {
+    # True when the host terminal can actually render a style, and therefore
+    # when it makes sense to load the style's prompt/banner at startup.
+    #
+    # Replaces the old Test-InWindowsTerminal gate. The original reasoning was
+    # "only WT renders the colors, so only load the themed prompt there" -- that
+    # reasoning is right, but WT is no longer the only terminal that qualifies.
+    # Any terminal that can take an OSC palette, or that we can write a config
+    # for, will render the style; a bare pipe or a dumb host will not.
+    param([string]$Kind = (Get-TerminalKind))
+    $caps = Get-TerminalCapability -Kind $Kind
+    return [bool]($caps.OscPalette -or $caps.Persist)
+}
+
+function Get-CurrentStyleRecordPath {
+    # Where the "which style is applied" record lives off Windows.
+    #
+    # On Windows Terminal the applied style is recoverable by reading the
+    # colorScheme name back out of settings.json, so no separate record is kept.
+    # Terminals driven by OSC have no such readback -- the escape sequences are
+    # fire-and-forget -- so the choice is recorded here instead. This is also
+    # what the startup re-emit reads to restore colors in a new tab.
+    Join-Path $script:TStylesDataRoot 'current-style.json'
+}
+
+function Set-CurrentStyleRecord {
+    # Record the applied style. Best-effort: a failure to write the record makes
+    # `tstyles current` and the startup re-emit forget the choice, but it must
+    # never take down an apply that already succeeded.
+    param(
+        [Parameter(Mandatory)][string]$StyleName,
+        [string]$Kind = (Get-TerminalKind)
+    )
+    try {
+        $record = [pscustomobject]@{
+            name      = $StyleName
+            terminal  = $Kind
+            appliedAt = (Get-Date).ToString('o', [System.Globalization.CultureInfo]::InvariantCulture)
+        }
+        $json = $record | ConvertTo-Json -Depth 5
+        [System.IO.File]::WriteAllText((Get-CurrentStyleRecordPath), $json, [System.Text.UTF8Encoding]::new($false))
+    } catch { }
+}
+
+function Get-CurrentStyleRecord {
+    # The recorded style, or $null when there is none / the file is unreadable
+    # or corrupt. Corruption self-heals: the next apply overwrites it.
+    $path = Get-CurrentStyleRecordPath
+    if (-not (Test-Path -LiteralPath $path)) { return $null }
+    try {
+        $json = [System.IO.File]::ReadAllText($path, [System.Text.UTF8Encoding]::new($false))
+        if (-not $json.Trim()) { return $null }
+        $record = $json | ConvertFrom-Json
+        if (-not $record.name) { return $null }
+        return $record
+    } catch {
+        return $null
+    }
+}
+
+function Clear-CurrentStyleRecord {
+    # Forget the applied style (used by `tstyles reset`). -Force so the write
+    # survives a read-only attribute; missing file is not an error.
+    $path = Get-CurrentStyleRecordPath
+    if (Test-Path -LiteralPath $path) {
+        Remove-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Write-HostOscPacket {
+    # Emit raw escape bytes to the terminal.
+    #
+    # [Console]::Out.Write, NOT Write-Host: Write-Host routes through the
+    # PowerShell host's formatting layer, which can swallow or re-encode control
+    # characters (and in a transcript or a redirected stream would write the
+    # escapes as visible text). Console.Out goes straight at stdout, which is
+    # where the terminal is listening. Flush so the repaint happens now rather
+    # than whenever the buffer next drains -- the picker depends on that
+    # immediacy for per-keystroke preview.
+    param([Parameter(Mandatory)][AllowEmptyString()][string]$Packet)
+    if (-not $Packet) { return }
+    try {
+        [Console]::Out.Write($Packet)
+        [Console]::Out.Flush()
+    } catch {
+        # A redirected/absent console (CI, a job runspace) has nothing to paint.
+        # Silent by design: colors are cosmetic, and throwing here would abort an
+        # otherwise-successful apply.
+    }
+}
+
+function Invoke-TerminalStyleOscApply {
+    # Retint the live terminal to $Scheme via OSC. Returns $true when the packet
+    # was emitted, $false when the terminal cannot take one.
+    param(
+        [Parameter(Mandatory)]$Scheme,
+        [string]$Kind = (Get-TerminalKind)
+    )
+    if (-not (Get-TerminalCapability -Kind $Kind).OscPalette) { return $false }
+    Write-HostOscPacket -Packet (Get-SchemeOscPacket -Scheme $Scheme)
+    return $true
+}
+
+function Invoke-TerminalStyleOscReset {
+    # Hand color control back to the terminal's own configured scheme.
+    param([string]$Kind = (Get-TerminalKind))
+    if (-not (Get-TerminalCapability -Kind $Kind).OscPalette) { return $false }
+    Write-HostOscPacket -Packet (Get-OscResetPacket)
+    return $true
+}

--- a/tests/Apply-StyleDirect-Backup.Tests.ps1
+++ b/tests/Apply-StyleDirect-Backup.Tests.ps1
@@ -50,7 +50,11 @@ Describe 'Apply-StyleDirect backup behavior' {
                 [System.Text.UTF8Encoding]::new($false)
             )
 
+            # Pin the terminal to Windows Terminal: these assertions are about the
+            # settings.json merge path, which only runs on WT. Without this the
+            # suite would take the OSC branch whenever it runs on macOS/Linux.
             Mock Find-WTSettingsPath        { $script:fakeSettings }
+            Mock Get-TerminalKind { 'WindowsTerminal' }
             Mock Show-UpdateNoticeIfAvailable {}
             Mock Get-CurrentWTProfileName   { 'PowerShell' }
             Mock Merge-StyleIntoSettings    { param($Settings) $Settings }

--- a/tests/Apply-StyleDirect-KeepPrompt.Tests.ps1
+++ b/tests/Apply-StyleDirect-KeepPrompt.Tests.ps1
@@ -35,7 +35,11 @@ Describe 'Apply-StyleDirect -KeepPrompt' {
             [System.IO.File]::WriteAllText((Join-Path $script:styleDir 'profile.ps1'),
                 '# fakeStyle prompt', [System.Text.UTF8Encoding]::new($false))
 
+            # Pin the terminal to Windows Terminal: these assertions are about the
+            # settings.json merge path, which only runs on WT. Without this the
+            # suite would take the OSC branch whenever it runs on macOS/Linux.
             Mock Find-WTSettingsPath          { $script:fakeSettings }
+            Mock Get-TerminalKind { 'WindowsTerminal' }
             Mock Show-UpdateNoticeIfAvailable {}
             Mock Merge-StyleIntoSettings      { param($Settings) $Settings }
             Mock Write-SettingsFile           {}

--- a/tests/Apply-StyleNonWT.Tests.ps1
+++ b/tests/Apply-StyleNonWT.Tests.ps1
@@ -1,0 +1,203 @@
+# Pester 5 tests for the non-Windows-Terminal apply/reset path and the
+# current-style record that backs it.
+#
+# These cover the branch taken on macOS/Linux terminals: no settings.json is
+# read or written, colors go out as an OSC packet, and the applied style is
+# recorded so a new tab can re-emit it at startup.
+#
+# Run: Invoke-Pester -Path tests
+# Requires: Pester 5+
+
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+BeforeDiscovery {
+    $repoRoot = Split-Path $PSScriptRoot -Parent
+    Import-Module (Join-Path $repoRoot 'TerminalStyles.psd1') -Force -DisableNameChecking *> $null
+}
+BeforeAll {
+    $repoRoot = Split-Path $PSScriptRoot -Parent
+    Import-Module (Join-Path $repoRoot 'TerminalStyles.psd1') -Force -DisableNameChecking *> $null
+}
+
+Describe 'current-style record' {
+    InModuleScope TerminalStyles {
+        BeforeEach {
+            $script:TStylesDataRoot = $TestDrive
+        }
+
+        It 'round-trips the applied style name' {
+            Set-CurrentStyleRecord -StyleName 'eva' -Kind 'AppleTerminal'
+            (Get-CurrentStyleRecord).name | Should -Be 'eva'
+        }
+
+        It 'records which terminal it was applied on' {
+            Set-CurrentStyleRecord -StyleName 'umbrella' -Kind 'ITerm2'
+            (Get-CurrentStyleRecord).terminal | Should -Be 'ITerm2'
+        }
+
+        It 'returns $null when no record exists' {
+            Clear-CurrentStyleRecord
+            Get-CurrentStyleRecord | Should -BeNullOrEmpty
+        }
+
+        It 'returns $null rather than throwing on a corrupt record' {
+            # Self-healing matters here: this runs at shell startup, and an
+            # exception would break every new tab until the file was deleted
+            # by hand.
+            [System.IO.File]::WriteAllText((Get-CurrentStyleRecordPath), '{not json at all',
+                [System.Text.UTF8Encoding]::new($false))
+            Get-CurrentStyleRecord | Should -BeNullOrEmpty
+        }
+
+        It 'returns $null for a record with no name field' {
+            [System.IO.File]::WriteAllText((Get-CurrentStyleRecordPath), '{"terminal":"ITerm2"}',
+                [System.Text.UTF8Encoding]::new($false))
+            Get-CurrentStyleRecord | Should -BeNullOrEmpty
+        }
+
+        It 'clears an existing record' {
+            Set-CurrentStyleRecord -StyleName 'eva' -Kind 'AppleTerminal'
+            Clear-CurrentStyleRecord
+            Test-Path -LiteralPath (Get-CurrentStyleRecordPath) | Should -BeFalse
+        }
+
+        It 'clearing a missing record is not an error' {
+            Clear-CurrentStyleRecord
+            { Clear-CurrentStyleRecord } | Should -Not -Throw
+        }
+
+        It 'overwrites rather than appends on re-apply' {
+            Set-CurrentStyleRecord -StyleName 'eva'      -Kind 'AppleTerminal'
+            Set-CurrentStyleRecord -StyleName 'umbrella' -Kind 'AppleTerminal'
+            (Get-CurrentStyleRecord).name | Should -Be 'umbrella'
+        }
+    }
+}
+
+Describe 'Invoke-TerminalStyleOscApply / Reset' {
+    InModuleScope TerminalStyles {
+        BeforeEach {
+            $script:emitted = @()
+            Mock Write-HostOscPacket { param($Packet) $script:emitted += $Packet }
+        }
+
+        It 'emits a packet on a terminal that supports OSC' {
+            $scheme = [pscustomobject]@{ name = 't'; background = '#000000'; foreground = '#ffffff' }
+            Invoke-TerminalStyleOscApply -Scheme $scheme -Kind 'AppleTerminal' | Should -BeTrue
+            Should -Invoke Write-HostOscPacket -Times 1
+        }
+
+        It 'emits nothing on a terminal without OSC support' {
+            # 'Unknown' does support OSC, so this needs a kind that genuinely
+            # cannot take one. Capability is what gates it, not the kind name.
+            Mock Get-TerminalCapability { @{ OscPalette = $false } }
+            $scheme = [pscustomobject]@{ name = 't'; background = '#000000' }
+            Invoke-TerminalStyleOscApply -Scheme $scheme -Kind 'AppleTerminal' | Should -BeFalse
+            Should -Invoke Write-HostOscPacket -Times 0
+        }
+
+        It 'emits the reset packet' {
+            Invoke-TerminalStyleOscReset -Kind 'AppleTerminal' | Should -BeTrue
+            $script:emitted -join '' | Should -Be (Get-OscResetPacket)
+        }
+    }
+}
+
+Describe 'Apply-StyleNonWT' {
+    InModuleScope TerminalStyles {
+        BeforeEach {
+            $script:TStylesDataRoot = $TestDrive
+            $script:TStylesCurrent  = Join-Path $TestDrive 'current-style.ps1'
+
+            # A minimal style on disk: scheme + a prompt to install.
+            $script:styleDir = Join-Path $TestDrive 'styles/fake'
+            New-Item -ItemType Directory -Force -Path $script:styleDir | Out-Null
+            [System.IO.File]::WriteAllText((Join-Path $script:styleDir 'scheme.json'),
+                '{"name":"fake","background":"#101010","foreground":"#f0f0f0"}',
+                [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText((Join-Path $script:styleDir 'profile.ps1'),
+                '# fake prompt', [System.Text.UTF8Encoding]::new($false))
+
+            Mock Get-TerminalKind { 'AppleTerminal' }
+            Mock Write-HostOscPacket { }
+            Mock Write-Host { }
+            # No bundled background: keeps the test off the network entirely.
+            Mock Get-StyleBundledBackground { $null }
+        }
+
+        It 'records the applied style' {
+            Apply-StyleNonWT -StyleName 'fake' -StyleDir $script:styleDir
+            (Get-CurrentStyleRecord).name | Should -Be 'fake'
+        }
+
+        It 'emits the color packet' {
+            Apply-StyleNonWT -StyleName 'fake' -StyleDir $script:styleDir
+            Should -Invoke Write-HostOscPacket -Times 1 -Scope It
+        }
+
+        It "installs the style's prompt to current-style.ps1" {
+            Apply-StyleNonWT -StyleName 'fake' -StyleDir $script:styleDir
+            Test-Path -LiteralPath $script:TStylesCurrent | Should -BeTrue
+        }
+
+        It '-KeepPrompt leaves the user prompt in control' {
+            # The style's visuals still apply; only the prompt install is skipped.
+            Apply-StyleNonWT -StyleName 'fake' -StyleDir $script:styleDir -KeepPrompt
+            Test-Path -LiteralPath $script:TStylesCurrent | Should -BeFalse
+            (Get-CurrentStyleRecord).name | Should -Be 'fake'
+        }
+
+        It '-KeepPrompt removes a prompt left by a previous apply' {
+            Apply-StyleNonWT -StyleName 'fake' -StyleDir $script:styleDir
+            Test-Path -LiteralPath $script:TStylesCurrent | Should -BeTrue
+            Apply-StyleNonWT -StyleName 'fake' -StyleDir $script:styleDir -KeepPrompt
+            Test-Path -LiteralPath $script:TStylesCurrent | Should -BeFalse
+        }
+
+        It 'never reads or writes a Windows Terminal settings.json' {
+            # The whole point of this branch: no settings file is involved.
+            Mock Find-WTSettingsPath { throw 'Find-WTSettingsPath must not be called off Windows Terminal' }
+            Mock Write-SettingsFile  { throw 'Write-SettingsFile must not be called off Windows Terminal' }
+            { Apply-StyleNonWT -StyleName 'fake' -StyleDir $script:styleDir } | Should -Not -Throw
+        }
+
+        It 'errors when the style has no scheme.json' {
+            $empty = Join-Path $TestDrive 'styles/empty'
+            New-Item -ItemType Directory -Force -Path $empty | Out-Null
+            { Apply-StyleNonWT -StyleName 'empty' -StyleDir $empty -ErrorAction Stop } | Should -Throw
+        }
+    }
+}
+
+Describe 'Reset-StyleNonWT' {
+    InModuleScope TerminalStyles {
+        BeforeEach {
+            $script:TStylesDataRoot = $TestDrive
+            $script:TStylesCurrent  = Join-Path $TestDrive 'current-style.ps1'
+            Mock Get-TerminalKind { 'AppleTerminal' }
+            Mock Write-HostOscPacket { }
+            Mock Write-Host { }
+        }
+
+        It 'clears the style record' {
+            Set-CurrentStyleRecord -StyleName 'eva' -Kind 'AppleTerminal'
+            Reset-StyleNonWT
+            Get-CurrentStyleRecord | Should -BeNullOrEmpty
+        }
+
+        It 'removes current-style.ps1 so the user prompt returns' {
+            [System.IO.File]::WriteAllText($script:TStylesCurrent, '# x', [System.Text.UTF8Encoding]::new($false))
+            Reset-StyleNonWT
+            Test-Path -LiteralPath $script:TStylesCurrent | Should -BeFalse
+        }
+
+        It 'emits the OSC reset packet' {
+            Reset-StyleNonWT
+            Should -Invoke Write-HostOscPacket -Times 1 -Scope It
+        }
+
+        It 'is safe to run when no style was ever applied' {
+            { Reset-StyleNonWT } | Should -Not -Throw
+        }
+    }
+}

--- a/tests/Font-Helpers.Tests.ps1
+++ b/tests/Font-Helpers.Tests.ps1
@@ -22,15 +22,28 @@ Describe 'Test-FontInstalled' {
 
 Describe 'Get-UserFontInstallPlan' {
     InModuleScope TerminalStyles {
+        # Paths are built with Join-Path / [IO.Path]::Combine rather than written
+        # as Windows literals. Both the function (Split-Path -Leaf) and the
+        # expectation resolve against the CURRENT platform's separator, so a
+        # hardcoded 'D:\Fonts\x.ttf' would be a single unsplit filename on
+        # macOS/Linux and the assertion would be testing nothing.
+        BeforeAll {
+            $script:SrcDir   = Join-Path (Join-Path $TestDrive 'src') 'tmp'
+            $script:FontsDir = Join-Path $TestDrive 'Fonts'
+        }
+
         It 'computes dest path and TrueType registry value name for a .ttf' {
-            $plan = Get-UserFontInstallPlan -FontFiles @('C:\tmp\JetBrainsMono-Regular.ttf') -FontsDir 'D:\Fonts'
+            $src  = Join-Path $script:SrcDir 'JetBrainsMono-Regular.ttf'
+            $plan = Get-UserFontInstallPlan -FontFiles @($src) -FontsDir $script:FontsDir
+            $expected = [System.IO.Path]::Combine($script:FontsDir, 'JetBrainsMono-Regular.ttf')
             @($plan).Count       | Should -Be 1
-            $plan[0].Dest        | Should -Be 'D:\Fonts\JetBrainsMono-Regular.ttf'
+            $plan[0].Dest        | Should -Be $expected
             $plan[0].ValueName   | Should -Be 'JetBrainsMono-Regular (TrueType)'
-            $plan[0].ValueData   | Should -Be 'D:\Fonts\JetBrainsMono-Regular.ttf'
+            $plan[0].ValueData   | Should -Be $expected
         }
         It 'uses OpenType for a .otf' {
-            $plan = Get-UserFontInstallPlan -FontFiles @('C:\tmp\SourceCodePro-Regular.otf') -FontsDir 'D:\Fonts'
+            $src  = Join-Path $script:SrcDir 'SourceCodePro-Regular.otf'
+            $plan = Get-UserFontInstallPlan -FontFiles @($src) -FontsDir $script:FontsDir
             $plan[0].ValueName | Should -Be 'SourceCodePro-Regular (OpenType)'
         }
     }

--- a/tests/Get-TerminalCapability.Tests.ps1
+++ b/tests/Get-TerminalCapability.Tests.ps1
@@ -1,0 +1,130 @@
+# Pester 5 tests for Get-TerminalCapability / Test-TerminalCapability
+# (module-private).
+#
+# The point of these is to pin the *shape* of the capability record and the
+# few invariants that callers rely on, not to re-assert every flag: a flag
+# table that only restates itself in a test is noise. The invariants that do
+# matter are the ones a future terminal block could quietly violate.
+#
+# Run: Invoke-Pester -Path tests
+# Requires: Pester 5+
+
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+BeforeDiscovery {
+    $repoRoot = Split-Path $PSScriptRoot -Parent
+    Import-Module (Join-Path $repoRoot 'TerminalStyles.psd1') -Force -DisableNameChecking *> $null
+}
+BeforeAll {
+    $repoRoot = Split-Path $PSScriptRoot -Parent
+    Import-Module (Join-Path $repoRoot 'TerminalStyles.psd1') -Force -DisableNameChecking *> $null
+}
+
+Describe 'Get-TerminalCapability' {
+    InModuleScope TerminalStyles {
+
+        $script:AllKinds = @('WindowsTerminal','AppleTerminal','ITerm2','Ghostty',
+                             'WezTerm','Kitty','Alacritty','VSCode','Unknown')
+
+        It 'returns a record covering exactly the declared capability names for <_>' -ForEach $script:AllKinds {
+            $caps = Get-TerminalCapability -Kind $_
+            # Sorted comparison: the record must be neither missing a declared
+            # capability nor carrying an undeclared one, or Test-TerminalCapability's
+            # guard becomes meaningless.
+            ($caps.Keys | Sort-Object) -join ',' |
+                Should -Be (($script:TStylesCapabilityNames | Sort-Object) -join ',')
+        }
+
+        It 'returns only boolean values for <_>' -ForEach $script:AllKinds {
+            $caps = Get-TerminalCapability -Kind $_
+            foreach ($v in $caps.Values) { $v | Should -BeOfType [bool] }
+        }
+
+        It 'grants Windows Terminal every capability' {
+            # WT is the reference implementation -- theme.json was defined against
+            # it, so anything it cannot do is a field no style should contain.
+            $caps = Get-TerminalCapability -Kind 'WindowsTerminal'
+            foreach ($n in $script:TStylesCapabilityNames) {
+                $caps[$n] | Should -BeTrue -Because "Windows Terminal should support $n"
+            }
+        }
+
+        It 'assumes OSC colors but nothing else for an unknown terminal' {
+            # Getting OscPalette wrong on an unknown terminal costs one ignored
+            # escape sequence; getting Persist wrong would mean writing a config
+            # file for a terminal that will never read it.
+            $caps = Get-TerminalCapability -Kind 'Unknown'
+            $caps.OscPalette | Should -BeTrue
+            foreach ($n in ($script:TStylesCapabilityNames | Where-Object { $_ -ne 'OscPalette' })) {
+                $caps[$n] | Should -BeFalse -Because "an unknown terminal must not be assumed to support $n"
+            }
+        }
+
+        It 'never claims Terminal.app can show a background image' {
+            # Terminal.app genuinely has no background-image feature. Claiming it
+            # would report "applied" for something the user can never see.
+            (Get-TerminalCapability -Kind 'AppleTerminal').BackgroundImage | Should -BeFalse
+        }
+
+        It 'claims OSC palette support for Terminal.app' {
+            # Verified by round-trip probe against Terminal.app 470: OSC 11 set to
+            # #ff00ff read back exactly, and OSC 111/104 restored the defaults.
+            (Get-TerminalCapability -Kind 'AppleTerminal').OscPalette | Should -BeTrue
+        }
+
+        It 'marks every terminal it can persist to as also able to set a font' {
+            # A persistable config that cannot carry a font would silently drop
+            # the style's font choice on apply.
+            foreach ($k in $script:AllKinds) {
+                $caps = Get-TerminalCapability -Kind $k
+                if ($caps.Persist) {
+                    $caps.Font | Should -BeTrue -Because "$k persists config, so it should carry a font"
+                }
+            }
+        }
+
+        It 'defaults -Kind to the live terminal' {
+            $direct = Get-TerminalCapability -Kind (Get-TerminalKind)
+            $implied = Get-TerminalCapability
+            ($implied.Keys | Sort-Object) -join ',' | Should -Be (($direct.Keys | Sort-Object) -join ',')
+            foreach ($n in $script:TStylesCapabilityNames) {
+                $implied[$n] | Should -Be $direct[$n]
+            }
+        }
+    }
+}
+
+Describe 'Test-TerminalCapability' {
+    InModuleScope TerminalStyles {
+
+        It 'agrees with the underlying capability record' {
+            Test-TerminalCapability -Capability 'BackgroundImage' -Kind 'WindowsTerminal' | Should -BeTrue
+            Test-TerminalCapability -Capability 'BackgroundImage' -Kind 'AppleTerminal'   | Should -BeFalse
+        }
+
+        It 'throws on an unknown capability name instead of returning false' {
+            # A typo'd capability silently reading as "unsupported" would disable
+            # a feature with no error anywhere -- the worst kind of bug to chase.
+            { Test-TerminalCapability -Capability 'Bacgkround' -Kind 'WindowsTerminal' } |
+                Should -Throw -ExpectedMessage '*Unknown terminal capability*'
+        }
+
+        It 'returns an actual boolean, not a truthy value' {
+            Test-TerminalCapability -Capability 'Persist' -Kind 'Unknown' | Should -BeOfType [bool]
+        }
+    }
+}
+
+Describe 'Get-TerminalDisplayName' {
+    InModuleScope TerminalStyles {
+        It 'gives a human-readable name for <_>' -ForEach @('WindowsTerminal','AppleTerminal','ITerm2','Unknown') {
+            Get-TerminalDisplayName -Kind $_ | Should -Not -BeNullOrEmpty
+        }
+        It 'does not leak the internal kind token for Windows Terminal' {
+            Get-TerminalDisplayName -Kind 'WindowsTerminal' | Should -Be 'Windows Terminal'
+        }
+        It 'falls back to a neutral phrase for an unrecognized kind' {
+            Get-TerminalDisplayName -Kind 'NoSuchTerm' | Should -Be 'this terminal'
+        }
+    }
+}

--- a/tests/Get-TerminalKind.Tests.ps1
+++ b/tests/Get-TerminalKind.Tests.ps1
@@ -1,0 +1,92 @@
+# Pester 5 tests for Get-TerminalKind (module-private).
+#
+# Detection is pure env-var inspection, so every case is driven through the
+# -EnvTable seam rather than by mutating the real $env: -- which would be
+# order-dependent and would break the host session's own detection.
+#
+# Run: Invoke-Pester -Path tests
+# Requires: Pester 5+
+
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+BeforeDiscovery {
+    $repoRoot = Split-Path $PSScriptRoot -Parent
+    Import-Module (Join-Path $repoRoot 'TerminalStyles.psd1') -Force -DisableNameChecking *> $null
+}
+BeforeAll {
+    $repoRoot = Split-Path $PSScriptRoot -Parent
+    Import-Module (Join-Path $repoRoot 'TerminalStyles.psd1') -Force -DisableNameChecking *> $null
+}
+
+Describe 'Get-TerminalKind' {
+    InModuleScope TerminalStyles {
+
+        It 'detects Windows Terminal from WT_SESSION' {
+            Get-TerminalKind -EnvTable @{ WT_SESSION = 'a-guid' } | Should -Be 'WindowsTerminal'
+        }
+
+        It 'detects Terminal.app from TERM_PROGRAM' {
+            Get-TerminalKind -EnvTable @{ TERM_PROGRAM = 'Apple_Terminal' } | Should -Be 'AppleTerminal'
+        }
+
+        It 'detects iTerm2 from ITERM_SESSION_ID' {
+            Get-TerminalKind -EnvTable @{ ITERM_SESSION_ID = 'w0t0p0' } | Should -Be 'ITerm2'
+        }
+
+        It 'detects iTerm2 from TERM_PROGRAM' {
+            Get-TerminalKind -EnvTable @{ TERM_PROGRAM = 'iTerm.app' } | Should -Be 'ITerm2'
+        }
+
+        It 'detects Ghostty from GHOSTTY_RESOURCES_DIR' {
+            Get-TerminalKind -EnvTable @{ GHOSTTY_RESOURCES_DIR = '/opt/ghostty' } | Should -Be 'Ghostty'
+        }
+
+        It 'detects WezTerm from TERM_PROGRAM' {
+            Get-TerminalKind -EnvTable @{ TERM_PROGRAM = 'WezTerm' } | Should -Be 'WezTerm'
+        }
+
+        It 'detects kitty from KITTY_WINDOW_ID' {
+            Get-TerminalKind -EnvTable @{ KITTY_WINDOW_ID = '1' } | Should -Be 'Kitty'
+        }
+
+        It 'detects Alacritty from ALACRITTY_WINDOW_ID' {
+            Get-TerminalKind -EnvTable @{ ALACRITTY_WINDOW_ID = '1' } | Should -Be 'Alacritty'
+        }
+
+        It 'detects the VS Code integrated terminal' {
+            Get-TerminalKind -EnvTable @{ TERM_PROGRAM = 'vscode' } | Should -Be 'VSCode'
+        }
+
+        It "returns 'Unknown' for a bare environment rather than guessing" {
+            Get-TerminalKind -EnvTable @{} | Should -Be 'Unknown'
+        }
+
+        It "returns 'Unknown' for an unrecognized TERM_PROGRAM" {
+            Get-TerminalKind -EnvTable @{ TERM_PROGRAM = 'SomeFutureTerm' } | Should -Be 'Unknown'
+        }
+
+        # Ordering matters: a Windows Terminal tab that has TERM_PROGRAM set
+        # (inherited through SSH, a multiplexer, or a VS Code launch) must still
+        # resolve as Windows Terminal, because WT is the host actually rendering.
+        It 'prefers WT_SESSION over a conflicting TERM_PROGRAM' {
+            Get-TerminalKind -EnvTable @{ WT_SESSION = 'a-guid'; TERM_PROGRAM = 'vscode' } |
+                Should -Be 'WindowsTerminal'
+        }
+
+        # ITERM_SESSION_ID survives a TERM_PROGRAM clobber, so it wins over a
+        # stale/foreign TERM_PROGRAM value.
+        It 'prefers ITERM_SESSION_ID over a conflicting TERM_PROGRAM' {
+            Get-TerminalKind -EnvTable @{ ITERM_SESSION_ID = 'w0t0p0'; TERM_PROGRAM = 'Apple_Terminal' } |
+                Should -Be 'ITerm2'
+        }
+
+        It 'reads the live environment when no -EnvTable is supplied' {
+            # Whatever is hosting the test run, the result must be one of the
+            # known kinds -- never $null or an empty string.
+            $kind = Get-TerminalKind
+            $kind | Should -Not -BeNullOrEmpty
+            @('WindowsTerminal','AppleTerminal','ITerm2','Ghostty','WezTerm',
+              'Kitty','Alacritty','VSCode','Unknown') | Should -Contain $kind
+        }
+    }
+}

--- a/tests/Get-TerminalStylesInstallKind.Tests.ps1
+++ b/tests/Get-TerminalStylesInstallKind.Tests.ps1
@@ -26,19 +26,35 @@ BeforeAll {
 
 Describe 'Get-TerminalStylesInstallKind' {
     InModuleScope TerminalStyles {
-        It "returns 'Bootstrap' when ModuleRoot equals %LOCALAPPDATA%\TerminalStyles" {
-            $script:TStylesModuleRoot = Join-Path $env:LOCALAPPDATA 'TerminalStyles'
+        # The bootstrap dir is wherever Get-TStylesDataRoot resolves to on THIS
+        # platform (%LOCALAPPDATA%\TerminalStyles on Windows, ~/Library/Application
+        # Support/TerminalStyles on macOS, $XDG_DATA_HOME/TerminalStyles on Linux).
+        # Deriving it from the same helper the function uses keeps the test
+        # meaningful everywhere instead of pinning it to Windows env vars, which
+        # are null off Windows.
+        BeforeAll {
+            $script:OriginalModuleRoot = $script:TStylesModuleRoot
+        }
+        AfterAll {
+            # Restore: $script:TStylesModuleRoot is module-wide state, and leaving
+            # a bogus value behind would leak into later tests in this run.
+            $script:TStylesModuleRoot = $script:OriginalModuleRoot
+        }
+
+        It "returns 'Bootstrap' when ModuleRoot equals the per-user data root" {
+            $script:TStylesModuleRoot = Get-TStylesDataRoot
             Get-TerminalStylesInstallKind | Should -Be 'Bootstrap'
         }
 
         It "returns 'PSResourceGet' when ModuleRoot is under a PSModulePath dir" {
             # Simulate a typical PSResourceGet install path
-            $script:TStylesModuleRoot = Join-Path $env:USERPROFILE 'Documents\PowerShell\Modules\TerminalStyles\0.2.0'
+            $script:TStylesModuleRoot =
+                Join-Path (Join-Path $HOME 'Documents/PowerShell/Modules/TerminalStyles') '0.2.0'
             Get-TerminalStylesInstallKind | Should -Be 'PSResourceGet'
         }
 
         It "returns 'PSResourceGet' when ModuleRoot is any path that isn't the bootstrap dir" {
-            $script:TStylesModuleRoot = 'C:\arbitrary\unrelated\path'
+            $script:TStylesModuleRoot = Join-Path $TestDrive 'arbitrary/unrelated/path'
             Get-TerminalStylesInstallKind | Should -Be 'PSResourceGet'
         }
     }

--- a/tests/Install-Font.Tests.ps1
+++ b/tests/Install-Font.Tests.ps1
@@ -11,16 +11,29 @@ BeforeAll {
 
 Describe 'Install-Font' {
     InModuleScope TerminalStyles {
-        It 'copies font files to the per-user dir and writes registry values' {
+        # Copying into the per-user font dir is the whole install on macOS
+        # (CoreText scans ~/Library/Fonts live) and on Linux; Windows needs an
+        # HKCU registration on top. So the copy is asserted everywhere and the
+        # registry half only where a registry exists.
+        It 'copies font files to the per-user dir' {
             $src = Join-Path $TestDrive 'Fake-Regular.ttf'
             [System.IO.File]::WriteAllText($src, 'FAKE')
             $fontsDir = Join-Path $TestDrive 'UserFonts'
+
+            $n = Install-Font -FontFiles @($src) -FontsDir $fontsDir
+            $n | Should -Be 1
+            Test-Path -LiteralPath (Join-Path $fontsDir 'Fake-Regular.ttf') | Should -BeTrue
+        }
+
+        It 'writes HKCU registry values' -Skip:((Get-TStylesPlatform) -ne 'Windows') {
+            $src = Join-Path $TestDrive 'Fake-Reg.ttf'
+            [System.IO.File]::WriteAllText($src, 'FAKE')
+            $fontsDir = Join-Path $TestDrive 'UserFontsReg'
             $regRoot  = 'HKCU:\Software\TerminalStylesTest\Fonts'
             try {
                 $n = Install-Font -FontFiles @($src) -FontsDir $fontsDir -RegistryRoot $regRoot
                 $n | Should -Be 1
-                Test-Path -LiteralPath (Join-Path $fontsDir 'Fake-Regular.ttf') | Should -BeTrue
-                (Get-ItemProperty -Path $regRoot).'Fake-Regular (TrueType)' | Should -Be (Join-Path $fontsDir 'Fake-Regular.ttf')
+                (Get-ItemProperty -Path $regRoot).'Fake-Reg (TrueType)' | Should -Be (Join-Path $fontsDir 'Fake-Reg.ttf')
             } finally {
                 if (Test-Path 'HKCU:\Software\TerminalStylesTest') {
                     Remove-Item 'HKCU:\Software\TerminalStylesTest' -Recurse -Force

--- a/tests/Invoke-TerminalStyle-HelpDispatch.Tests.ps1
+++ b/tests/Invoke-TerminalStyle-HelpDispatch.Tests.ps1
@@ -44,7 +44,11 @@ Describe 'tstyles unknown-arg fallback' {
             Mock Show-TerminalStyleHelp {}
             Mock Show-UpdateNoticeIfAvailable {}
             Mock Get-AvailableStyles { @() }   # nothing matches the arg
+            # Pin the terminal to Windows Terminal: these assertions are about the
+            # settings.json merge path, which only runs on WT. Without this the
+            # suite would take the OSC branch whenever it runs on macOS/Linux.
             Mock Find-WTSettingsPath { throw 'picker path must not be reached' }
+            Mock Get-TerminalKind { 'WindowsTerminal' }
             { Invoke-TerminalStyle -Arg 'definitely-not-a-real-thing' } | Should -Not -Throw
             Should -Invoke Show-TerminalStyleHelp -Times 1
             Should -Not -Invoke Find-WTSettingsPath

--- a/tests/Invoke-TerminalStyleTune.Tests.ps1
+++ b/tests/Invoke-TerminalStyleTune.Tests.ps1
@@ -30,7 +30,11 @@ Describe 'Invoke-TerminalStyleTune guards' {
         }
         It 'errors when settings.json cannot be located' {
             Mock Get-StyleDir { $TestDrive }
+            # Pin the terminal to Windows Terminal: these assertions are about the
+            # settings.json merge path, which only runs on WT. Without this the
+            # suite would take the OSC branch whenever it runs on macOS/Linux.
             Mock Find-WTSettingsPath { $null }
+            Mock Get-TerminalKind { 'WindowsTerminal' }
             Mock Show-UpdateNoticeIfAvailable {}
             Mock Write-Error {}
             # Provide a scheme.json so the base load would succeed past resolution.

--- a/tests/Reset-StyleDirect.Tests.ps1
+++ b/tests/Reset-StyleDirect.Tests.ps1
@@ -33,7 +33,11 @@ Describe 'Reset-StyleDirect' {
             [System.IO.File]::WriteAllText($script:fakeSettings,
                 ($settingsObj | ConvertTo-Json -Depth 32), [System.Text.UTF8Encoding]::new($false))
 
+            # Pin the terminal to Windows Terminal: these assertions are about the
+            # settings.json merge path, which only runs on WT. Without this the
+            # suite would take the OSC branch whenever it runs on macOS/Linux.
             Mock Find-WTSettingsPath          { $script:fakeSettings }
+            Mock Get-TerminalKind { 'WindowsTerminal' }
             Mock Show-UpdateNoticeIfAvailable {}
             Mock Get-CurrentWTProfileName     { 'PowerShell' }
             Mock Write-SettingsFile           { param($Path, $Settings) $script:written = $Settings }

--- a/tests/Test-UpdateAvailable.Tests.ps1
+++ b/tests/Test-UpdateAvailable.Tests.ps1
@@ -39,8 +39,12 @@ Describe 'Test-UpdateAvailable' {
             Mock Get-TerminalStylesInstallKind { 'Bootstrap' }
             $stampFile = Join-Path $TestDrive '.last-update-check'
             $shaFile   = Join-Path $TestDrive '.installed-sha'
-            Remove-Item $stampFile -ErrorAction SilentlyContinue
-            Remove-Item $shaFile   -ErrorAction SilentlyContinue
+            # -Force is required, not optional: both names start with a dot, and
+            # on macOS/Linux a dotfile is hidden -- Remove-Item skips hidden items
+            # unless forced. Without it the previous test's throttle stamp would
+            # survive into this one and suppress the API call under test.
+            Remove-Item $stampFile -Force -ErrorAction SilentlyContinue
+            Remove-Item $shaFile   -Force -ErrorAction SilentlyContinue
         }
 
         It 'returns $null and skips the API when the stamp is fresh (< 24h)' {

--- a/tstyles.ps1
+++ b/tstyles.ps1
@@ -13,11 +13,85 @@ $script:TStylesModuleRoot = $PSScriptRoot
 if (-not $script:TStylesModuleRoot) {
     $script:TStylesModuleRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 }
-# Stable per-user data dir. Survives module version upgrades (PSResourceGet
-# installs a new version to a sibling dir; state stays here). For bootstrap-
-# installed users, this happens to equal $script:TStylesModuleRoot --
-# backward-compatible by design.
-$script:TStylesDataRoot = Join-Path $env:LOCALAPPDATA 'TerminalStyles'
+function Get-TStylesPlatform {
+    # 'Windows' | 'MacOS' | 'Linux'. The automatic $IsWindows/$IsMacOS/$IsLinux
+    # variables only exist on PowerShell 6+; Windows PowerShell 5.1 predates
+    # them and is Windows by definition, so branch on the major version first.
+    # (Referencing $IsWindows under 5.1 would silently yield $null, not $true.)
+    if ($PSVersionTable.PSVersion.Major -lt 6) { return 'Windows' }
+    if ($IsWindows) { return 'Windows' }
+    if ($IsMacOS)   { return 'MacOS' }
+    return 'Linux'
+}
+
+function Get-TStylesDataRoot {
+    # Stable per-user data dir. Survives module version upgrades (PSResourceGet
+    # installs a new version to a sibling dir; state stays here). For bootstrap-
+    # installed Windows users this happens to equal $script:TStylesModuleRoot --
+    # backward-compatible by design, which is why Windows keeps %LOCALAPPDATA%
+    # verbatim rather than moving to a new cross-platform location.
+    #
+    # -Platform / -HomeDir are test seams; real callers omit them.
+    param(
+        [string]$Platform = (Get-TStylesPlatform),
+        [string]$HomeDir  = $HOME
+    )
+    switch ($Platform) {
+        'Windows' {
+            # $env:LOCALAPPDATA is the historical location. Fall back to the
+            # profile-relative path if the var is somehow unset (bare service
+            # accounts, stripped environments) so we never Join-Path a $null.
+            $base = $env:LOCALAPPDATA
+            if (-not $base) { $base = Join-Path $HomeDir 'AppData\Local' }
+            return Join-Path $base 'TerminalStyles'
+        }
+        'MacOS' {
+            return Join-Path (Join-Path $HomeDir 'Library/Application Support') 'TerminalStyles'
+        }
+        default {
+            # XDG Base Directory spec: honour $XDG_DATA_HOME, else ~/.local/share.
+            $base = $env:XDG_DATA_HOME
+            if (-not $base) { $base = Join-Path (Join-Path $HomeDir '.local') 'share' }
+            return Join-Path $base 'TerminalStyles'
+        }
+    }
+}
+
+function Get-TStylesFontDir {
+    # Per-user font directory -- the one a font can be dropped into WITHOUT
+    # admin/root. Platform differences run deeper than the path:
+    #   Windows: copy + an HKCU registry value + a GDI AddFontResource broadcast
+    #   macOS:   copy alone is enough; CoreText picks up ~/Library/Fonts live
+    #   Linux:   copy alone, though fontconfig may need `fc-cache` to notice
+    # Install-Font branches on Get-TStylesPlatform for those extra steps.
+    #
+    # -Platform / -HomeDir are test seams; real callers omit them.
+    param(
+        [string]$Platform = (Get-TStylesPlatform),
+        [string]$HomeDir  = $HOME
+    )
+    switch ($Platform) {
+        'Windows' {
+            $base = $env:LOCALAPPDATA
+            if (-not $base) { $base = Join-Path $HomeDir 'AppData\Local' }
+            return Join-Path $base 'Microsoft\Windows\Fonts'
+        }
+        'MacOS' { return Join-Path (Join-Path $HomeDir 'Library') 'Fonts' }
+        default {
+            $base = $env:XDG_DATA_HOME
+            if (-not $base) { $base = Join-Path (Join-Path $HomeDir '.local') 'share' }
+            return Join-Path $base 'fonts'
+        }
+    }
+}
+
+# Terminal detection + capability model. Dot-sourced (not a nested module) so
+# it shares $script: scope with everything below -- Get-TerminalCapability reads
+# $script:TStylesCapabilityNames, and the adapters need $script:TStylesDataRoot.
+. (Join-Path $script:TStylesModuleRoot 'terminals.ps1')
+
+$script:TStylesPlatform = Get-TStylesPlatform
+$script:TStylesDataRoot = Get-TStylesDataRoot
 if (-not (Test-Path -LiteralPath $script:TStylesDataRoot)) {
     New-Item -ItemType Directory -Path $script:TStylesDataRoot -Force | Out-Null
 }
@@ -68,10 +142,15 @@ function Get-StyleCacheDir {
     # Single source of truth shared by Get-StyleBundledBackground, Test-StyleResolved,
     # and the picker's prefetch job so the writer and the readers can never drift.
     # The prefetch job runs in a separate runspace without $script: scope, so it
-    # re-derives the same path from $env:LOCALAPPDATA -- keep this formula in sync
-    # with that derivation (Join-Path $DataRoot "cache\<name>").
+    # re-derives the same path from the data root -- keep this formula in sync
+    # with that derivation (Join-Path (Join-Path $DataRoot 'cache') <name>).
+    #
+    # Nested Join-Path, NOT "cache\$StyleName": the 3-argument Join-Path is
+    # PowerShell 6+ only (WinPS 5.1 takes two positional paths), and a literal
+    # backslash is not a separator on macOS/Linux -- it would produce a single
+    # file named "cache\eva" instead of the cache/eva directory.
     param([Parameter(Mandatory)][string]$StyleName)
-    Join-Path $script:TStylesDataRoot "cache\$StyleName"
+    Join-Path (Join-Path $script:TStylesDataRoot 'cache') $StyleName
 }
 
 function Get-StyleBundledBackground {
@@ -163,7 +242,7 @@ function Invoke-TerminalStylesStateMigration {
 
     foreach ($styleDir in Get-ChildItem -LiteralPath $stylesDir -Directory) {
         $styleName = $styleDir.Name
-        $cacheDir = Join-Path $script:TStylesDataRoot "cache\$styleName"
+        $cacheDir = Join-Path (Join-Path $script:TStylesDataRoot 'cache') $styleName
 
         # Move cached background files
         foreach ($ext in 'gif','png','jpg','jpeg') {
@@ -207,7 +286,7 @@ function Get-TerminalStylesInstallKind {
     # Note: $script:TStylesModuleRoot is set during module load. For installs
     # made before the dual-root refactor (sub-project C), the variable still
     # has the right value because the init block sets it from $PSScriptRoot.
-    $bootstrapDir = Join-Path $env:LOCALAPPDATA 'TerminalStyles'
+    $bootstrapDir = Get-TStylesDataRoot
     if ($script:TStylesModuleRoot -eq $bootstrapDir) { return 'Bootstrap' }
     return 'PSResourceGet'
 }
@@ -667,10 +746,10 @@ function Get-StyleDir {
     # union-and-dedup precedence.
     param([Parameter(Mandatory)][string]$StyleName)
 
-    $userDir = Join-Path $script:TStylesDataRoot "styles\$StyleName"
+    $userDir = Join-Path (Join-Path $script:TStylesDataRoot 'styles') $StyleName
     if (Test-Path -LiteralPath (Join-Path $userDir 'scheme.json')) { return $userDir }
 
-    $bundledDir = Join-Path $script:TStylesModuleRoot "styles\$StyleName"
+    $bundledDir = Join-Path (Join-Path $script:TStylesModuleRoot 'styles') $StyleName
     if (Test-Path -LiteralPath (Join-Path $bundledDir 'scheme.json')) { return $bundledDir }
 
     return $null
@@ -706,14 +785,25 @@ function Get-CurrentStyleName {
     # Detects which bundled style is currently active by byte-comparing
     # current-style.ps1 against each style's profile.ps1. Returns $null
     # if nothing matches (custom profile, no current style, etc).
-    if (-not (Test-Path -LiteralPath $script:TStylesCurrent)) { return $null }
-    $current = [System.IO.File]::ReadAllText($script:TStylesCurrent, [System.Text.UTF8Encoding]::new($false))
-    foreach ($style in (Get-AvailableStyles)) {
-        $sp = Join-Path $style.FullName 'profile.ps1'
-        if (-not (Test-Path -LiteralPath $sp)) { continue }
-        $styleContent = [System.IO.File]::ReadAllText($sp, [System.Text.UTF8Encoding]::new($false))
-        if ($current -eq $styleContent) { return $style.Name }
+    if (Test-Path -LiteralPath $script:TStylesCurrent) {
+        $current = [System.IO.File]::ReadAllText($script:TStylesCurrent, [System.Text.UTF8Encoding]::new($false))
+        foreach ($style in (Get-AvailableStyles)) {
+            $sp = Join-Path $style.FullName 'profile.ps1'
+            if (-not (Test-Path -LiteralPath $sp)) { continue }
+            $styleContent = [System.IO.File]::ReadAllText($sp, [System.Text.UTF8Encoding]::new($false))
+            if ($current -eq $styleContent) { return $style.Name }
+        }
     }
+
+    # Fall back to the recorded style. The byte-compare above can't see a style
+    # applied with -KeepPrompt (which deliberately leaves current-style.ps1
+    # absent) -- on OSC-driven terminals that would report "no style" while the
+    # colors are plainly applied. The record knows regardless of the prompt.
+    $record = Get-CurrentStyleRecord
+    if ($record -and $record.name) {
+        if (Get-StyleDir -StyleName $record.name) { return $record.name }
+    }
+
     return $null
 }
 
@@ -864,11 +954,97 @@ function Invoke-RandomStyle {
     Apply-StyleDirect -StyleName $pick.Name
 }
 
+function Apply-StyleNonWT {
+    # Apply a style on a terminal that is not Windows Terminal.
+    #
+    # There is no settings.json to merge into, so the work splits in two:
+    #   * colors    -- emitted as an OSC packet, which retints the CURRENT tab
+    #                  instantly. Recorded in current-style.json so the startup
+    #                  block at the bottom of this file can re-emit it into
+    #                  every future tab.
+    #   * prompt    -- the style's profile.ps1 is copied to current-style.ps1
+    #                  and dot-sourced, exactly as on Windows Terminal. That
+    #                  file is plain PowerShell + ANSI and is already portable.
+    #
+    # Fields the host terminal cannot honour (a background image on Terminal.app,
+    # a tab accent color anywhere but WT) are reported rather than silently
+    # dropped, so the user knows why the style looks plainer than its screenshot.
+    param(
+        [Parameter(Mandatory)][string]$StyleName,
+        [Parameter(Mandatory)][string]$StyleDir,
+        [switch]$KeepPrompt
+    )
+
+    $kind = Get-TerminalKind
+    $caps = Get-TerminalCapability -Kind $kind
+
+    $schemePath = Join-Path $StyleDir 'scheme.json'
+    if (-not (Test-Path -LiteralPath $schemePath)) {
+        Write-Error "Style '$StyleName' has no scheme.json."
+        return
+    }
+    $scheme = [System.IO.File]::ReadAllText($schemePath, [System.Text.UTF8Encoding]::new($false)) | ConvertFrom-Json
+
+    $applied = Invoke-TerminalStyleOscApply -Scheme $scheme -Kind $kind
+    Set-CurrentStyleRecord -StyleName $StyleName -Kind $kind
+
+    # Prompt/banner: same contract as the Windows Terminal path.
+    $styleProfile = Join-Path $StyleDir 'profile.ps1'
+    if (-not $KeepPrompt -and (Test-Path -LiteralPath $styleProfile)) {
+        Copy-Item -LiteralPath $styleProfile -Destination $script:TStylesCurrent -Force
+    } elseif (Test-Path -LiteralPath $script:TStylesCurrent) {
+        Remove-Item -LiteralPath $script:TStylesCurrent -Force
+    }
+
+    Write-Host ""
+    Write-Host "  Style applied: " -NoNewline
+    Write-Host $StyleName -ForegroundColor Green
+    Write-Host "  Terminal:      " -NoNewline
+    Write-Host (Get-TerminalDisplayName -Kind $kind) -ForegroundColor Cyan
+
+    if (-not $applied) {
+        Write-Host ""
+        Write-Host "  Note: this terminal did not accept live color changes, so only the prompt was applied." -ForegroundColor Yellow
+    }
+
+    # Tell the user which parts of the style this terminal cannot show, once,
+    # rather than letting them wonder why it doesn't match the screenshot.
+    $unsupported = @()
+    $theme = $null
+    $themePath = Join-Path $StyleDir 'theme.json'
+    if (Test-Path -LiteralPath $themePath) {
+        try {
+            $theme = [System.IO.File]::ReadAllText($themePath, [System.Text.UTF8Encoding]::new($false)) | ConvertFrom-Json
+        } catch { $theme = $null }
+    }
+    if ($theme) {
+        if ((Get-StyleBundledBackground -StyleDir $StyleDir) -and -not $caps.BackgroundImage) {
+            $unsupported += 'background image'
+        }
+        if ($theme.PSObject.Properties.Match('tabColor').Count -gt 0 -and -not $caps.TabColor) {
+            $unsupported += 'tab color'
+        }
+    }
+    if ($unsupported.Count -gt 0) {
+        Write-Host ""
+        Write-Host ("  {0} can't show: {1}." -f (Get-TerminalDisplayName -Kind $kind), ($unsupported -join ', ')) -ForegroundColor DarkGray
+    }
+    Write-Host ""
+
+    # Live reload of the prompt in THIS shell (matches the WT confirm path).
+    if (Test-Path -LiteralPath $script:TStylesCurrent) {
+        . $script:TStylesCurrent
+    }
+}
+
 function Apply-StyleDirect {
     # Apply a style directly (no picker UI). Used by `tstyles <name>` and
     # `tstyles random`. Mirrors the picker's confirm path -- merge into
     # settings.json, copy profile.ps1 to current-style.ps1, dot-source for
     # live reload.
+    #
+    # Off Windows Terminal the settings.json half does not exist; Apply-StyleNonWT
+    # takes over with the OSC + current-style.json path instead.
     param(
         [Parameter(Mandatory)][string]$StyleName,
         [string]$Target,
@@ -886,6 +1062,12 @@ function Apply-StyleDirect {
     }
 
     Show-UpdateNoticeIfAvailable
+
+    # Non-WT hosts have no settings.json; hand off before we go looking for one.
+    if ((Get-TerminalKind) -ne 'WindowsTerminal') {
+        Apply-StyleNonWT -StyleName $StyleName -StyleDir $styleDir -KeepPrompt:$KeepPrompt
+        return
+    }
 
     $settingsPath = Find-WTSettingsPath
     if (-not $settingsPath) {
@@ -1096,7 +1278,7 @@ function Invoke-TerminalStylesUninstall {
         [switch]$DeleteData    # also remove %LOCALAPPDATA%\TerminalStyles\ (user state)
     )
 
-    $dataDir = Join-Path $env:LOCALAPPDATA 'TerminalStyles'
+    $dataDir = Get-TStylesDataRoot
     $kind = Get-TerminalStylesInstallKind
 
     Write-Host ""
@@ -1449,7 +1631,7 @@ function Get-UserFontInstallPlan {
     # value names. No filesystem/registry writes happen here.
     param(
         [Parameter(Mandatory)][string[]]$FontFiles,
-        [string]$FontsDir = (Join-Path $env:LOCALAPPDATA 'Microsoft\Windows\Fonts')
+        [string]$FontsDir = (Get-TStylesFontDir)
     )
     foreach ($f in $FontFiles) {
         $leaf = Split-Path -Leaf $f
@@ -1534,13 +1716,19 @@ function Install-Font {
     # reload) see them. -FontsDir / -RegistryRoot are test seams.
     param(
         [Parameter(Mandatory)][string[]]$FontFiles,
-        [string]$FontsDir = (Join-Path $env:LOCALAPPDATA 'Microsoft\Windows\Fonts'),
+        [string]$FontsDir = (Get-TStylesFontDir),
         [string]$RegistryRoot = 'HKCU:\Software\Microsoft\Windows NT\CurrentVersion\Fonts'
     )
     if (-not (Test-Path -LiteralPath $FontsDir)) {
         New-Item -ItemType Directory -Path $FontsDir -Force | Out-Null
     }
-    if (-not (Test-Path -LiteralPath $RegistryRoot)) {
+
+    # Registration is a Windows-only concept. On macOS, CoreText scans
+    # ~/Library/Fonts and picks up a dropped file immediately -- no registry, no
+    # broadcast. On Linux, fontconfig indexes the dir (fc-cache below nudges it).
+    $isWindows = (Get-TStylesPlatform) -eq 'Windows'
+
+    if ($isWindows -and -not (Test-Path -LiteralPath $RegistryRoot)) {
         New-Item -Path $RegistryRoot -Force | Out-Null
     }
 
@@ -1548,8 +1736,23 @@ function Install-Font {
     $count = 0
     foreach ($p in $plan) {
         Copy-Item -LiteralPath $p.Source -Destination $p.Dest -Force
-        New-ItemProperty -Path $RegistryRoot -Name $p.ValueName -Value $p.ValueData -PropertyType String -Force | Out-Null
+        if ($isWindows) {
+            New-ItemProperty -Path $RegistryRoot -Name $p.ValueName -Value $p.ValueData -PropertyType String -Force | Out-Null
+        }
         $count++
+    }
+
+    if (-not $isWindows) {
+        # Best-effort cache refresh for fontconfig (Linux, and macOS setups that
+        # have it via Homebrew). Absent on a stock Mac, where it isn't needed.
+        if ((Get-TStylesPlatform) -eq 'Linux') {
+            try {
+                if (Get-Command fc-cache -ErrorAction SilentlyContinue) {
+                    & fc-cache -f $FontsDir *> $null
+                }
+            } catch { }
+        }
+        return $count
     }
 
     # Activate in this session (best effort; the file+registry install is the
@@ -1720,7 +1923,7 @@ function Save-TunedStyle {
         [int]$Brightness, [int]$Saturation, [int]$Opacity,
         [string]$FontFace, [int]$FontSize
     )
-    $destDir = Join-Path $script:TStylesDataRoot "styles\$SaveName"
+    $destDir = Join-Path (Join-Path $script:TStylesDataRoot 'styles') $SaveName
     if (-not (Test-Path -LiteralPath $destDir)) {
         New-Item -ItemType Directory -Path $destDir -Force | Out-Null
     }
@@ -1923,7 +2126,7 @@ function Invoke-TerminalStyleTune {
     }
 
     # --- Scratch dir for the debounced settings.json preview (reuses Merge) ---
-    $scratchDir = Join-Path $script:TStylesDataRoot ".tune-preview\$baseName"
+    $scratchDir = Join-Path (Join-Path $script:TStylesDataRoot '.tune-preview') $baseName
     if (-not (Test-Path -LiteralPath $scratchDir)) {
         New-Item -ItemType Directory -Path $scratchDir -Force | Out-Null
     }
@@ -2092,7 +2295,7 @@ function Invoke-TerminalStyleTune {
                     Write-Host "  Use letters, digits, dot, underscore, or hyphen only." -ForegroundColor Yellow
                     continue
                 }
-                $bundledDir = Join-Path $script:TStylesModuleRoot "styles\$candidate"
+                $bundledDir = Join-Path (Join-Path $script:TStylesModuleRoot 'styles') $candidate
                 if (Test-Path -LiteralPath (Join-Path $bundledDir 'scheme.json')) {
                     $warn = (Read-Host "  That shadows bundled '$candidate'. Continue? [y/N]").Trim()
                     if ($warn -notmatch '^(?i)y') { continue }
@@ -2285,14 +2488,50 @@ function Test-InWindowsTerminal {
     return [bool]$env:WT_SESSION
 }
 
+function Reset-StyleNonWT {
+    # `tstyles reset` off Windows Terminal.
+    #
+    # Nothing was written to a settings file, so there is nothing to strip --
+    # the applied colors live entirely in the terminal's dynamic-color state.
+    # OSC 104/110/111/112/117 hands that state back to the terminal's own
+    # configured profile, which is exactly what "unstyled default" means here.
+    $kind = Get-TerminalKind
+
+    [void](Invoke-TerminalStyleOscReset -Kind $kind)
+    Clear-CurrentStyleRecord
+
+    # Restore the user's own prompt by removing the style's loader target. The
+    # prompt function already installed in THIS session stays until the shell
+    # restarts -- same behaviour as the Windows Terminal path.
+    if (Test-Path -LiteralPath $script:TStylesCurrent) {
+        Remove-Item -LiteralPath $script:TStylesCurrent -Force -ErrorAction SilentlyContinue
+    }
+
+    Write-Host ""
+    Write-Host "  Reset " -NoNewline
+    Write-Host (Get-TerminalDisplayName -Kind $kind) -ForegroundColor Cyan -NoNewline
+    Write-Host " to its unstyled default."
+    Write-Host "  Open a new tab to restore your default prompt."
+    Write-Host ""
+}
+
 function Reset-StyleDirect {
     # `tstyles reset [-Target <name>]` -- revert a WT profile to its unstyled
     # default: strip the fields TerminalStyles writes, remove the now-orphan
     # color scheme, and clear current-style.ps1 (restore the user's prompt).
     # Inverse of Apply-StyleDirect. Writes a rolling .bak first.
+    #
+    # Off Windows Terminal there is no settings.json to strip: the reset is an
+    # OSC 104/110-117 packet that hands color control back to the terminal's own
+    # profile, plus dropping the style record and current-style.ps1.
     param([string]$Target)
 
     Show-UpdateNoticeIfAvailable
+
+    if ((Get-TerminalKind) -ne 'WindowsTerminal') {
+        Reset-StyleNonWT
+        return
+    }
 
     $settingsPath = Find-WTSettingsPath
     if (-not $settingsPath) {
@@ -2565,10 +2804,21 @@ function Invoke-TerminalStyle {
     # but Test-UpdateAvailable short-circuits inside the 24h throttle window.
     Show-UpdateNoticeIfAvailable
 
-    $settingsPath = Find-WTSettingsPath
-    if (-not $settingsPath) {
-        Write-Error "Could not locate Windows Terminal settings.json."
-        return
+    # Windows Terminal previews a style by writing settings.json and letting WT
+    # reload; every other terminal previews purely through the OSC packet the
+    # render loop already emits. So settings.json handling is conditional from
+    # here down: $useSettingsFile gates the read, the snapshot, the per-arrow
+    # writes, and the Esc revert.
+    $termKind        = Get-TerminalKind
+    $useSettingsFile = ($termKind -eq 'WindowsTerminal')
+
+    $settingsPath = $null
+    if ($useSettingsFile) {
+        $settingsPath = Find-WTSettingsPath
+        if (-not $settingsPath) {
+            Write-Error "Could not locate Windows Terminal settings.json."
+            return
+        }
     }
 
     # Enumerate via the shared helper so the picker shows user + tuned styles
@@ -2586,19 +2836,38 @@ function Invoke-TerminalStyle {
     # which mangles non-ASCII profile names (e.g. "Símbolo del sistema").
     # The mangled string then round-trips through ConvertTo-Json + WriteAllText
     # as UTF-8, doubling the byte count of non-ASCII chars on every call.
-    $originalJson = [System.IO.File]::ReadAllText($settingsPath, [System.Text.UTF8Encoding]::new($false))
-    $originalSettings = ConvertFrom-WTJson $originalJson
+    $originalJson     = $null
+    $originalSettings = $null
+    if ($useSettingsFile) {
+        $originalJson = [System.IO.File]::ReadAllText($settingsPath, [System.Text.UTF8Encoding]::new($false))
+        $originalSettings = ConvertFrom-WTJson $originalJson
 
-    if (-not $Target) { $Target = Get-CurrentWTProfileName -Settings $originalSettings }
-    if (-not $Target) {
-        Write-Host "Could not auto-detect the current Windows Terminal profile."
-        Write-Host "Available: $((@('defaults') + @($originalSettings.profiles.list.name)) -join ', ')"
-        $Target = (Read-Host "Target profile").Trim()
-        if (-not $Target) { return }
+        if (-not $Target) { $Target = Get-CurrentWTProfileName -Settings $originalSettings }
+        if (-not $Target) {
+            Write-Host "Could not auto-detect the current Windows Terminal profile."
+            Write-Host "Available: $((@('defaults') + @($originalSettings.profiles.list.name)) -join ', ')"
+            $Target = (Read-Host "Target profile").Trim()
+            if (-not $Target) { return }
+        }
     }
 
-    if (-not (Test-InWindowsTerminal)) {
-        Write-Host "Note: color scheme + background only render in Windows Terminal; this host shows a plain prompt." -ForegroundColor Yellow
+    # Single choke point for every settings.json write in the picker. Off
+    # Windows Terminal this is a no-op, so the loop below reads the same in
+    # both worlds instead of repeating the guard at each call site.
+    $writeSettings = {
+        param([string]$Json)
+        if ($useSettingsFile -and $Json) {
+            Write-SettingsAtomic -Path $settingsPath -Json $Json
+        }
+    }
+
+    if (-not (Test-StyledHost -Kind $termKind)) {
+        Write-Host "Note: this host doesn't render colors; you'll get the prompt but not the palette." -ForegroundColor Yellow
+    } elseif (-not $useSettingsFile) {
+        $caps = Get-TerminalCapability -Kind $termKind
+        if (-not $caps.BackgroundImage) {
+            Write-Host ("Note: {0} renders the palette but not background images." -f (Get-TerminalDisplayName -Kind $termKind)) -ForegroundColor DarkGray
+        }
     }
 
     # Start on the currently active style if we can detect one -- opening
@@ -2679,7 +2948,7 @@ function Invoke-TerminalStyle {
                 # (kept in sync with Get-StyleCacheDir). Writing into $styleDir
                 # instead would be a no-op on read-only PSGallery installs and would
                 # strand the .no-background marker where no reader looks.
-                $cacheDir = Join-Path $DataRoot "cache\$styleName"
+                $cacheDir = Join-Path (Join-Path $DataRoot 'cache') $styleName
                 if (-not (Test-Path -LiteralPath $cacheDir)) {
                     try { New-Item -ItemType Directory -Path $cacheDir -Force | Out-Null } catch { continue }
                 }
@@ -2718,18 +2987,25 @@ function Invoke-TerminalStyle {
     # memory on Esc, but a hard kill mid-preview would otherwise leave the
     # last-previewed theme with no recoverable original; this .bak (same one the
     # direct-apply/reset paths roll) is that recovery copy.
-    try { [System.IO.File]::WriteAllText("$settingsPath.bak", $originalJson, [System.Text.UTF8Encoding]::new($false)) } catch { }
+    # Crash-recovery copy -- only meaningful when a settings.json exists.
+    if ($useSettingsFile) { try { [System.IO.File]::WriteAllText("$settingsPath.bak", $originalJson, [System.Text.UTF8Encoding]::new($false)) } catch { } }
 
     [Console]::CursorVisible = $false
     $originalTitle = $Host.UI.RawUI.WindowTitle
     try {
-        # Apply first preview before showing the menu
-        $preview = ConvertFrom-WTJson $originalJson
-        $preview = Merge-StyleIntoSettings -Settings $preview -StyleDir $styles[$idx].FullName -TargetName $Target -BackgroundImage $BackgroundImage -BackgroundImageProvided $bgProvided
-        $initialJson = $preview | ConvertTo-Json -Depth 100
-        Write-SettingsAtomic -Path $settingsPath -Json $initialJson
-        if (Test-StyleResolved -StyleDir $styles[$idx].FullName) {
-            $mergedCache[$idx] = $initialJson
+        # Apply first preview before showing the menu. The merge is skipped
+        # entirely off Windows Terminal: there is no $originalJson to merge into,
+        # and the OSC packet emitted by the render loop is the whole preview.
+        if ($useSettingsFile) {
+            $preview = ConvertFrom-WTJson $originalJson
+            $preview = Merge-StyleIntoSettings -Settings $preview -StyleDir $styles[$idx].FullName -TargetName $Target -BackgroundImage $BackgroundImage -BackgroundImageProvided $bgProvided
+            $initialJson = $preview | ConvertTo-Json -Depth 100
+            & $writeSettings $initialJson
+            if (Test-StyleResolved -StyleDir $styles[$idx].FullName) {
+                $mergedCache[$idx] = $initialJson
+            }
+        } else {
+            Write-HostOscPacket -Packet $oscPackets[$idx]
         }
         if ($titles.ContainsKey($idx)) { $Host.UI.RawUI.WindowTitle = $titles[$idx] }
 
@@ -2814,14 +3090,20 @@ function Invoke-TerminalStyle {
 
         $applyTheme = {
             param([int]$i)
+            # Off Windows Terminal the OSC retint in $onRetint already did the
+            # whole preview -- there is no deferred settings.json write to make.
+            if (-not $useSettingsFile) {
+                if ($titles.ContainsKey($i)) { $Host.UI.RawUI.WindowTitle = $titles[$i] }
+                return
+            }
             $resolved = Test-StyleResolved -StyleDir $styles[$i].FullName
             if ($resolved -and $mergedCache.ContainsKey($i)) {
-                Write-SettingsAtomic -Path $settingsPath -Json $mergedCache[$i]
+                & $writeSettings $mergedCache[$i]
             } else {
                 $preview = ConvertFrom-WTJson $originalJson
                 $preview = Merge-StyleIntoSettings -Settings $preview -StyleDir $styles[$i].FullName -TargetName $Target -BackgroundImage $BackgroundImage -BackgroundImageProvided $bgProvided
                 $json = $preview | ConvertTo-Json -Depth 100
-                Write-SettingsAtomic -Path $settingsPath -Json $json
+                & $writeSettings $json
                 if ($resolved) { $mergedCache[$i] = $json }
             }
             if ($titles.ContainsKey($i)) { $Host.UI.RawUI.WindowTitle = $titles[$i] }
@@ -2834,7 +3116,7 @@ function Invoke-TerminalStyle {
         # Esc: restore the byte-exact original settings.json and clear the live
         # OSC retint so the cancelled preview's colors don't linger.
         $onRevert = {
-            Write-SettingsAtomic -Path $settingsPath -Json $originalJson
+            & $writeSettings $originalJson
             [Console]::Out.Write((Get-OscResetPacket))
         }
 
@@ -2848,6 +3130,8 @@ function Invoke-TerminalStyle {
                 $nextPrebuild = $j
                 break
             }
+            # Nothing to prebuild when no settings.json is being written.
+            if (-not $useSettingsFile) { Start-Sleep -Milliseconds 50; return }
             if ($nextPrebuild -ge 0) {
                 $pp = ConvertFrom-WTJson $originalJson
                 $pp = Merge-StyleIntoSettings -Settings $pp -StyleDir $styles[$nextPrebuild].FullName -TargetName $Target -BackgroundImage $BackgroundImage -BackgroundImageProvided $bgProvided
@@ -2881,18 +3165,29 @@ function Invoke-TerminalStyle {
         $selectedStyle = $styles[$idx]
         $styleProfile  = Join-Path $selectedStyle.FullName 'profile.ps1'
 
-        $isPwshTarget = $false
-        if ($Target -eq 'defaults') {
-            $isPwshTarget = $true
-        } else {
-            $entry = $originalSettings.profiles.list | Where-Object name -eq $Target | Select-Object -First 1
-            $cmd = "$($entry.commandline)"
-            $src = "$($entry.source)"
-            if ($src -eq 'Windows.Terminal.PowershellCore' -or
-                $cmd -match '(?i)\bpwsh\.exe\b' -or
-                $cmd -match '(?i)\bpowershell\.exe\b') {
+        # "Is the target a PowerShell profile?" is a Windows Terminal question:
+        # it decides whether writing a PowerShell prompt into that WT profile
+        # makes sense. Off WT there are no profiles to disambiguate -- this shell
+        # IS PowerShell, so the prompt always applies.
+        $isPwshTarget = $true
+        if ($useSettingsFile) {
+            $isPwshTarget = $false
+            if ($Target -eq 'defaults') {
                 $isPwshTarget = $true
+            } else {
+                $entry = $originalSettings.profiles.list | Where-Object name -eq $Target | Select-Object -First 1
+                $cmd = "$($entry.commandline)"
+                $src = "$($entry.source)"
+                if ($src -eq 'Windows.Terminal.PowershellCore' -or
+                    $cmd -match '(?i)\bpwsh\.exe\b' -or
+                    $cmd -match '(?i)\bpowershell\.exe\b') {
+                    $isPwshTarget = $true
+                }
             }
+        } else {
+            # Record the confirmed style so a new tab comes up in it -- the OSC
+            # preview alone would die with this tab.
+            Set-CurrentStyleRecord -StyleName $styles[$idx].Name -Kind $termKind
         }
 
         if ($isPwshTarget) {
@@ -2959,10 +3254,42 @@ Register-ArgumentCompleter -CommandName Invoke-TerminalStyle -ParameterName Arg 
 # Idempotent; gated by a marker file.
 Invoke-TerminalStylesStateMigration
 
-# === Auto-load the currently selected style's profile.ps1 (Windows Terminal only) ===
-# Skipped outside WT: other hosts (VS Code, Visual Studio, conhost) don't render
-# the style's colors/background, so loading the prompt/banner there would be a
-# half-themed look. Module functions are already imported regardless.
-if ((Test-InWindowsTerminal) -and (Test-Path -LiteralPath $script:TStylesCurrent)) {
-    . $script:TStylesCurrent
+# === Auto-load the currently selected style at shell startup ===
+# Gated on Test-StyledHost rather than Test-InWindowsTerminal: hosts that cannot
+# render a style (a plain pipe, a dumb console) would show a half-themed look --
+# banner and prompt glyphs with none of the colors. Every terminal that CAN take
+# an OSC palette or a written config qualifies. Module functions import
+# regardless of the gate.
+if (Test-StyledHost) {
+
+    # Windows Terminal reads its colors from settings.json, which the apply
+    # already wrote, so the palette is live before this shell even starts.
+    # OSC-driven terminals have no such persistence: the escape sequences only
+    # ever touched the tab they were emitted into. Re-emit them here so a new
+    # tab/window/split comes up in the applied style instead of the terminal's
+    # own default.
+    #
+    # Skipped on WT to avoid fighting its own scheme, and skipped when the
+    # terminal can persist a real config AND we wrote one (that path handles
+    # itself). Failures are swallowed inside Write-HostOscPacket -- a missing
+    # color is never worth blocking a shell from starting.
+    if ((Get-TerminalKind) -ne 'WindowsTerminal') {
+        try {
+            $record = Get-CurrentStyleRecord
+            if ($record -and $record.name) {
+                $styleDir = Get-StyleDir -StyleName $record.name
+                if ($styleDir) {
+                    $schemePath = Join-Path $styleDir 'scheme.json'
+                    if (Test-Path -LiteralPath $schemePath) {
+                        $scheme = [System.IO.File]::ReadAllText($schemePath, [System.Text.UTF8Encoding]::new($false)) | ConvertFrom-Json
+                        [void](Invoke-TerminalStyleOscApply -Scheme $scheme)
+                    }
+                }
+            }
+        } catch { }
+    }
+
+    if (Test-Path -LiteralPath $script:TStylesCurrent) {
+        . $script:TStylesCurrent
+    }
 }


### PR DESCRIPTION
**Draft — work in progress.** Opened primarily so CI verifies the Windows legs, since this touches shared code paths that previously only ever ran on Windows Terminal.

## What this does

Makes TerminalStyles work outside Windows Terminal. Three layers:

**Platform foundation.** `Get-TStylesPlatform` / `Get-TStylesDataRoot` / `Get-TStylesFontDir` resolve per-user state and font dirs per OS. Windows keeps `%LOCALAPPDATA%` verbatim so existing installs are untouched; macOS uses `~/Library/Application Support`, Linux honours `$XDG_DATA_HOME`. `install.ps1` carries duplicated copies (it runs before the module exists) and no longer depends on `$env:TEMP`.

**Terminal detection + capabilities** (`terminals.ps1`). `Get-TerminalKind` identifies the host from env markers; `Get-TerminalCapability` reports which style fields it can honour. Callers degrade against the capability record instead of writing settings nothing reads — and say what the terminal *can't* show rather than silently dropping it.

**Apply/reset without a settings.json.** Colors go out as an OSC packet; the applied style is recorded in `current-style.json` and re-emitted at shell startup so new tabs come up styled. Reset emits OSC 104/110–117. The picker's settings.json writes now run through one guarded choke point, so its live preview and Esc-revert work unchanged on both paths.

## Terminal.app supports OSC dynamic colors

Verified by round-trip probe against Terminal.app 470:

```
OSC11 query   -> rgb:213d/2743/33e7      (answered)
OSC11 set     -> #ff00ff read back as ff00/0000/ff00
OSC111 reset  -> rgb:213d/2743/33e7      (restored)
OSC4/104      -> same, for the 16-color palette
```

So `Get-SchemeOscPacket` / `Get-OscResetPacket` needed **no changes** — live preview works there natively, no AppleScript on the hot path.

## Latent bugs found

- `tstyles.ps1:20` built the data root with `Join-Path $env:LOCALAPPDATA`, which is null off Windows — the whole module failed to import, taking 52 tests with it.
- Five `Join-Path` calls embedded a literal `\` (`"cache\$name"`), which isn't a separator on macOS/Linux.
- A test cleaned up dot-prefixed fixtures with `Remove-Item` and no `-Force`. Dotfiles are hidden on Unix, so the delete was a silent no-op and a stale throttle stamp leaked between tests.

## Testing

521 passing / 0 failing on macOS (pwsh 7.7-preview), 3 Windows-only cases skipped. Tests asserting the settings.json merge now pin `Get-TerminalKind` to `'WindowsTerminal'` so they exercise that path on any host.

**Windows verification is what this PR is for** — I have no Windows machine here.

## Still to do before this leaves draft

- [ ] zsh/bash prompt ports (16 styles × 2 shells) + shell loader + `tstyles` shim for non-pwsh users
- [ ] macOS font handling (`System.Drawing` is Windows-only in .NET 6+, so monospace detection needs another approach)
- [ ] iTerm2 Dynamic Profile + Terminal.app `.terminal` plist persistence
- [ ] `macos-latest` CI leg
- [ ] README / manifest description + tags still say Windows Terminal only

🤖 Generated with [Claude Code](https://claude.com/claude-code)