### PR TITLE
Handle invalid colors in scheme swatches

### DIFF
--- a/lib/color.ps1
+++ b/lib/color.ps1
@@ -40,6 +40,7 @@ function Get-SchemeSwatch {
         if ($picks.Count -ge 5) { break }
         if (-not $hex) { continue }
         $key = ([string]$hex).TrimStart('#').ToLowerInvariant()
+        if ($key -notmatch '^[0-9a-f]{6}$') { continue }
         if ($seen.ContainsKey($key)) { continue }
         $seen[$key] = $true
         $picks += $hex

--- a/tests/Get-SchemeSwatch.Tests.ps1
+++ b/tests/Get-SchemeSwatch.Tests.ps1
@@ -58,6 +58,27 @@ Describe 'Get-SchemeSwatch' {
         }
     }
 
+
+    Context 'Malformed colors' {
+        It 'skips invalid hex values instead of throwing' {
+            InModuleScope TerminalStyles {
+                $scheme = [pscustomobject]@{
+                    background          = '#101010'
+                    foreground          = 'not-a-color'
+                    cursorColor         = '#202020'
+                    brightRed           = '#zzzzzz'
+                    brightCyan          = '#303030'
+                    selectionBackground = '#12345'
+                    brightPurple        = '#404040'
+                    brightYellow        = '#505050'
+                }
+
+                { $script:swatch = Get-SchemeSwatch -Scheme $scheme } | Should -Not -Throw
+                ([regex]::Matches($script:swatch, '\[48;2;(\d+;\d+;\d+)m')).Count | Should -Be 5
+            }
+        }
+    }
+
     Context 'Across all themes' {
         It 'every pair of themes produces a byte-distinct swatch' {
             $repoRoot = Split-Path $PSScriptRoot -Parent


### PR DESCRIPTION
## What and why

Fixes #6.

`Get-SchemeSwatch` already skipped short color strings, but malformed values with six or more characters could still reach `Substring()`/`ToInt32()` and throw while rendering the swatch. This makes the swatch path fragile when a scheme contains an invalid color value.

## Solution

Validate normalized color values with `^[0-9a-f]{6}$` before adding them to the swatch picks. Invalid values are ignored the same way missing and too-short values already are.

## Checks

- Added a regression test covering invalid hex values such as `not-a-color`, `#zzzzzz`, and short hex strings.
- `git diff --check` passes.
- Could not run Pester locally because `pwsh` is not installed in this environment.

## Checklist

- [ ] `Invoke-Pester -Path tests` is green locally on at least one engine — CI runs both pwsh 7 and Windows PowerShell 5.1
- [x] New behavior has tests
- [x] The diff stays focused on one change
