### PR TITLE
fix(shell): the runtime defined bare names in the user's shell, and nothing measured it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- the shell runtime no longer defines bare names in the user's shell. `shell/tstyles.sh` is sourced from the rc file on every interactive shell, so it is the one file guaranteed to run for every user -- and it was the one file outside the leak check added in 0.8.21, which measured only `styles/<name>/prompt.sh`. It carried `TS_LOADED` and `TS_SHELL` as bare names while the project enforced `_ts_` on all sixteen styles; they are now `_ts_loaded` and `_ts_shell`. `TSTYLES_DATA` deliberately stays: the runtime reads it before deriving a default, and the test suite uses that seam to point a shell at a scratch data root, so it is a contract rather than a leak. The measurement now covers the runtime too -- sourced in a real zsh with the variable table diffed across it, the same authority the style check uses, rather than a regex that a second column or an `eval` can step around
+
 ## [0.8.21] - 2026-09-02
 
 ### Added

--- a/shell/tstyles.sh
+++ b/shell/tstyles.sh
@@ -29,11 +29,11 @@ fi
 # --- Shell identification --------------------------------------------------
 # Set once, so the per-prompt path does no detection work.
 if [ -n "$ZSH_VERSION" ]; then
-    TS_SHELL='zsh'
+    _ts_shell='zsh'
 elif [ -n "$BASH_VERSION" ]; then
-    TS_SHELL='bash'
+    _ts_shell='bash'
 else
-    TS_SHELL='sh'
+    _ts_shell='sh'
 fi
 
 # --- Color helpers ---------------------------------------------------------
@@ -49,7 +49,7 @@ fi
 #
 # The ESC byte itself also differs: bash expands \033 (octal) inside PS1, but
 # zsh does not expand backslash escapes in PROMPT, so zsh needs a literal ESC.
-if [ "$TS_SHELL" = 'zsh' ]; then
+if [ "$_ts_shell" = 'zsh' ]; then
     ts_c() { printf '%%{\033[38;2;%sm%%}' "$1"; }
     ts_x() { printf '%%{\033[0m%%}'; }
 else
@@ -66,7 +66,7 @@ fi
 # What bash accepts post-expansion is the raw bytes it would have decoded to:
 # \001 and \002 around a real ESC. zsh re-scans substitution output for prompt
 # escapes under PROMPT_SUBST, so there %{...%} still works and these match ts_c.
-if [ "$TS_SHELL" = 'zsh' ]; then
+if [ "$_ts_shell" = 'zsh' ]; then
     ts_cs() { printf '%%{\033[38;2;%sm%%}' "$1"; }
     ts_xs() { printf '%%{\033[0m%%}'; }
 else
@@ -94,7 +94,7 @@ ts_rawx() { printf '\033[0m'; }
 # with a sed s|…|…| delimiter.
 ts_prompt_expand() {
     _ts_tpl="$1"
-    if [ "$TS_SHELL" = 'zsh' ]; then
+    if [ "$_ts_shell" = 'zsh' ]; then
         _ts_cwd='%~'      # full path, ~-abbreviated
         _ts_leaf='%1~'    # last component only
         _ts_user='%n'
@@ -131,7 +131,7 @@ ts_git_branch() {
     # "100", the CURRENT DIRECTORY (%d), then "one", and a '%(' swallowed the
     # rest of the prompt as a malformed ternary. Doubling makes each '%'
     # literal. bash does no such re-scan, so it is left alone there.
-    if [ "$TS_SHELL" = 'zsh' ]; then
+    if [ "$_ts_shell" = 'zsh' ]; then
         # The backslash matters: an unescaped % is a zsh glob pattern and
         # ${b//%/%%} appends rather than replaces (verified: 100%done ->
         # 100%done%%). ${b//\%/%%} is correct in both zsh and bash.
@@ -142,7 +142,7 @@ ts_git_branch() {
 
 ts_prompt_apply() {
     # Install $1 (an already-expanded template) as the shell's prompt.
-    if [ "$TS_SHELL" = 'zsh' ]; then
+    if [ "$_ts_shell" = 'zsh' ]; then
         # PROMPT_SUBST lets $(ts_git_branch) re-run on each prompt; without it
         # zsh would show the command substitution literally. It cannot expand
         # anything from the filesystem: the directory reaches the prompt as the
@@ -199,10 +199,10 @@ ts_load() {
     # TWICE on every new window. Set after the interactivity check, so a
     # non-interactive shell that returned above does not poison a later
     # interactive load in the same process.
-    if [ -n "$TS_LOADED" ]; then
+    if [ -n "$_ts_loaded" ]; then
         return 0
     fi
-    TS_LOADED=1
+    _ts_loaded=1
 
     # 1. Colors. The packet was rendered at apply time.
     if [ -r "$TSTYLES_DATA/current-style.osc" ]; then

--- a/tests/Shell-Prompt.Tests.ps1
+++ b/tests/Shell-Prompt.Tests.ps1
@@ -263,3 +263,45 @@ Describe 'a style leaks nothing into the user shell -- measured, not linted' {
             -Because "sourcing $_/prompt.sh replaced the user's own $($leaked -join ', ')"
     }
 }
+
+Describe 'the runtime itself leaks nothing into the user shell -- measured, not linted' {
+    # The Describe above measures styles/<name>/prompt.sh. It never measured
+    # shell/tstyles.sh, which is sourced from the user's rc file on EVERY
+    # interactive shell -- so the one file guaranteed to run for every user was
+    # the one file outside the leak check. It was carrying TS_LOADED and
+    # TS_SHELL, bare names in the user's namespace, while the project enforced
+    # `_ts_` on the sixteen styles.
+    #
+    # TSTYLES_DATA is the deliberate exception and stays: the runtime reads it
+    # before deriving a default (`if [ -z "$TSTYLES_DATA" ]`), and this suite
+    # depends on that seam to point a shell at a scratch data root. It is a
+    # documented-by-use contract, not a leak. Anything else is.
+    BeforeDiscovery {
+        # Decided HERE, at discovery, for the reason spelled out above: a -Skip
+        # reading a BeforeAll variable gets $null and silently passes.
+        $script:NoZshRuntime = -not (Get-Command zsh -ErrorAction SilentlyContinue)
+    }
+
+    It 'defines no bare name in a real zsh' -Skip:$script:NoZshRuntime {
+        $repoRoot  = Split-Path $PSScriptRoot -Parent
+        $runtimeSh = Join-Path (Join-Path $repoRoot 'shell') 'tstyles.sh'
+
+        $script = @(
+            'ts_before=$(typeset +m "*" 2>/dev/null)'
+            "source ${runtimeSh} >/dev/null 2>&1"
+            'ts_after=$(typeset +m "*" 2>/dev/null)'
+            'comm -13 <(print -r -- "$ts_before" | sort -u) <(print -r -- "$ts_after" | sort -u)'
+        ) -join "`n"
+
+        $sf = Join-Path $TestDrive 'leak-runtime.zsh'
+        [System.IO.File]::WriteAllText($sf, $script, [System.Text.UTF8Encoding]::new($false))
+
+        $out = & zsh -f $sf 2>$null
+        $leaked = @($out | Where-Object {
+                       $_ -and $_ -notmatch '^(_ts_|ts_before$|ts_after$|TSTYLES_DATA$)'
+                   } | Sort-Object -Unique)
+
+        $leaked -join ', ' | Should -BeNullOrEmpty `
+            -Because "sourcing shell/tstyles.sh replaced the user's own $($leaked -join ', ')"
+    }
+}

--- a/tests/Shell-Runtime-Escaping.Tests.ps1
+++ b/tests/Shell-Runtime-Escaping.Tests.ps1
@@ -287,7 +287,7 @@ echo READY
     It 'sets the guard only after the interactivity check' {
         $src = [System.IO.File]::ReadAllText($script:runtime, [System.Text.UTF8Encoding]::new($false))
         $body = [regex]::Match($src, '(?s)ts_load\(\) \{.*?\n\}').Value
-        $body.IndexOf('case "$-"') | Should -BeLessThan $body.IndexOf('TS_LOADED=1')
+        $body.IndexOf('case "$-"') | Should -BeLessThan $body.IndexOf('_ts_loaded=1')
     }
 }
 


### PR DESCRIPTION
Follow-on to the leak work in 0.8.21, closing the gap that work left.

## The gap

0.8.21 replaced a regex lint with a **measurement** — source the file in a real zsh, diff the variable table across it — because the lint had been stepped around by a second assignment in the second column and had certified nine leaking styles as clean for four releases.

That measurement scoped itself to `styles/<name>/prompt.sh`.

`shell/tstyles.sh` was never in scope. It is sourced from the user's rc file on **every interactive shell**, so it is the one file guaranteed to run for every user of this tool — and it was the one file the check did not cover. Measured:

```
$ comm -13 before after
TSTYLES_DATA
TS_LOADED
TS_SHELL
```

Two bare names in the user's namespace, while the project enforces `_ts_` on all sixteen styles.

## What changed

`TS_LOADED` → `_ts_loaded`, `TS_SHELL` → `_ts_shell`. No style references either — they use the `ts_*` functions — and neither appears in README, CONTRIBUTING, docs or any style README, so nothing outside the runtime can be relying on the old names.

**`TSTYLES_DATA` deliberately stays.** The runtime reads it before deriving a default (`if [ -z "$TSTYLES_DATA" ]`), and this suite depends on that seam to point a shell at a scratch data root. It is a contract, not a leak, and the new test names it as the single exception rather than silently tolerating it.

The measurement now covers the runtime on the same terms as the styles, with the `-Skip` decided at **discovery** — a `-Skip` reading a `BeforeAll` variable gets `$null` and silently passes, which this suite has been bitten by before.

## Verification

- **1426 passed, 0 failed** (+1 new test).
- **Mutation-checked**: reverting the rename turns the new test red, naming the offender — `Expected $null or empty ... but got 'TS_SHELL'`.
- **Re-exercised end to end** against a sandboxed `HOME`, because a 10-site rename in a shell runtime is not something a static test proves:
  - the zsh prompt renders identically, `%{…%}` non-printing markers intact;
  - a login bash still prints **one** banner, not two — the `_ts_loaded` guard still doing its job under its new name, on the `.bash_profile`-sources-`.bashrc` path it exists for.

## Scope note

This came out of a systematic audit for off-Windows bugs, which otherwise found none — `$env:USERNAME`/`COMPUTERNAME` fallbacks, `LOCALAPPDATA` guards, registry gating, `-EditMode`, path containment and the Terminal.app colour map all check out. I also confirmed empirically that 0.8.21's colour-space fix round-trips byte-exact: decoding the generated `eva.terminal` gives back `#0a0006`, `#ffe8e8`, `#ff3d5a`, `#c41e3a`, `#d4ddf0` in `NSDeviceRGBColorSpace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fc4mE7gSHoux5wL6VEo59S