### PR TITLE
fix(shell): the loader written into ~/.profile could never be removed, by anything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **the loader block written into `~/.profile` could never be removed, by anything.** `tstyles shell-init` registers there in the one layout where it is the only file the login shell will read -- a home with a `~/.profile` and no `.bash_profile`, where creating one would shadow a file already in use. But `~/.profile` is not a REGISTRATION candidate (it is sh's file, not bash's, and writing to it unasked would reach past the shells this tool claims), and removal walked the registration list. So `tstyles shell-remove` printed "removed from ~/.bashrc" and "Open a new tab to get your original prompt back" while the block sat in `~/.profile` -- precisely the file the login shell reads -- and `tstyles uninstall` left it pointing at a data root it had just deleted, on every login shell, with nothing left on the machine able to remove it and no message that it was there. Removal now walks `Get-ShellRcRemovalCandidate`, a superset of what is written to; a file with no block is untouched and one that does not exist is never created, so the wider sweep costs nothing where it was never used.
+
+  The test that was supposed to guarantee this asserted that shell-init and uninstall both mention `Get-ShellRcCandidate`. Sharing a helper name is not symmetry, and it passed for the whole life of the bug. It is now backed by a round-trip across six rc layouts: run init, run remove, and count the markers left on disk.
+
 ### Changed
 
 - the shell runtime no longer defines bare names in the user's shell. `shell/tstyles.sh` is sourced from the rc file on every interactive shell, so it is the one file guaranteed to run for every user -- and it was the one file outside the leak check added in 0.8.21, which measured only `styles/<name>/prompt.sh`. It carried `TS_LOADED` and `TS_SHELL` as bare names while the project enforced `_ts_` on all sixteen styles; they are now `_ts_loaded` and `_ts_shell`. `TSTYLES_DATA` deliberately stays: the runtime reads it before deriving a default, and the test suite uses that seam to point a shell at a scratch data root, so it is a contract rather than a leak. The measurement now covers the runtime too -- sourced in a real zsh with the variable table diffed across it, the same authority the style check uses, rather than a regex that a second column or an `eval` can step around

--- a/lib/update.ps1
+++ b/lib/update.ps1
@@ -495,7 +495,9 @@ function Invoke-TerminalStylesUninstall {
     # `tstyles` command could no longer load the module. That left hand-editing
     # ~/.zshrc as the only recovery.
     $shellRemoved = 0
-    foreach ($c in (Get-ShellRcCandidate)) {
+    # The removal superset, not the registration list: shell-init can register
+    # into ~/.profile, and sweeping the narrow list orphaned that block forever.
+    foreach ($c in (Get-ShellRcRemovalCandidate)) {
         # Explicit comparison: Unregister-ShellLoader returns a STATUS now, and
         # every status -- including 'none' -- is a truthy string.
         if ((Unregister-ShellLoader -Path $c.Path) -eq 'removed') {

--- a/terminals.ps1
+++ b/terminals.ps1
@@ -593,6 +593,51 @@ function Get-ShellRcCandidate {
     )
 }
 
+
+function Get-ShellRcRemovalCandidate {
+    <#
+    .SYNOPSIS
+    Every rc file the loader could be IN -- a superset of the files it is
+    written to.
+
+    .DESCRIPTION
+    Registration and removal are not the same list, and treating them as one
+    left a block that nothing could ever take out.
+
+    `Get-ShellRcCandidate` is the REGISTRATION list, and ~/.profile is
+    deliberately not on it: it is sh's file rather than bash's, and writing to
+    it unasked would reach past the shells this tool claims. But shell-init
+    registers there anyway in the one case where it is the only file the login
+    shell will read -- a home with a ~/.profile and no .bash_profile, where
+    creating a .bash_profile would shadow a file already in use. Two branches
+    do this (the .bashrc-exists branch and the nothing-existed fallback).
+
+    Removal iterated the REGISTRATION list, so it never looked at ~/.profile.
+    `tstyles shell-remove` reported "removed from ~/.bashrc" and "Open a new tab
+    to get your original prompt back" while the block sat in ~/.profile, which
+    is precisely the file the login shell reads. After `tstyles uninstall` it
+    pointed at a deleted data root, on every login shell, with nothing left on
+    the machine to remove it and no message that it was there.
+
+    So: write to the narrow list, sweep the wide one. A file with no block
+    returns 'none' from Unregister-ShellLoader and a file that does not exist is
+    never created, so the extra entry costs nothing when it was never used.
+    #>
+    param(
+        # Same seams as Get-ShellRcCandidate, forwarded exactly -- binding
+        # -HomeDir there means a sandbox and suppresses the ambient $env:ZDOTDIR,
+        # and that rule has to survive the hop through here.
+        [string]$HomeDir = $HOME,
+        [string]$ZDotDir
+    )
+    $splat = @{}
+    if ($PSBoundParameters.ContainsKey('HomeDir')) { $splat.HomeDir = $HomeDir }
+    if ($PSBoundParameters.ContainsKey('ZDotDir')) { $splat.ZDotDir = $ZDotDir }
+
+    @(Get-ShellRcCandidate @splat) +
+    @([pscustomobject]@{ Shell = 'sh'; Path = (Join-Path $HomeDir '.profile') })
+}
+
 function Get-RcFileEncoding {
     <#
     .SYNOPSIS
@@ -797,6 +842,11 @@ function Invoke-TerminalStylesShellInit {
     $candidates = Get-ShellRcCandidate @splat
 
     if ($Remove) {
+        # The WIDE list: shell-init can register into ~/.profile, which is not a
+        # registration candidate. Sweeping the narrow list left that block in
+        # place while reporting the loader removed.
+        $candidates = Get-ShellRcRemovalCandidate @splat
+
         # Each status reported for what it is. A failure and a malformed block
         # both used to read as "nothing was registered", so the user was told
         # the loader was gone while every new shell still sourced it.

--- a/tests/Uninstall-ReversesShellInit.Tests.ps1
+++ b/tests/Uninstall-ReversesShellInit.Tests.ps1
@@ -93,8 +93,12 @@ Describe 'uninstall reverses shell-init' {
     InModuleScope TerminalStyles {
 
         It 'strips the loader from every rc file it registered into' {
+            # Get-ShellRcRemovalCandidate, not Get-ShellRcCandidate: the file set
+            # written to is a SUBSET of the file set that must be swept, because
+            # shell-init also registers into ~/.profile. Asserting the narrow name
+            # here is what let that block become unremovable.
             $src = (Get-Command Invoke-TerminalStylesUninstall).ScriptBlock.ToString()
-            $src | Should -Match 'Get-ShellRcCandidate'
+            $src | Should -Match 'Get-ShellRcRemovalCandidate'
             $src | Should -Match 'Unregister-ShellLoader'
         }
 
@@ -223,13 +227,35 @@ Describe 'Get-UninstallPlan' {
 Describe 'shell-init and uninstall agree on where the loader lives' {
     InModuleScope TerminalStyles {
 
-        It 'both walk Get-ShellRcCandidate' {
+        It 'both resolve their file list from the shared helpers' {
             # If uninstall ever hardcoded its own list, a candidate added to
             # shell-init would silently stop being removable.
+            #
+            # Removal deliberately walks the WIDER list: shell-init can register
+            # into ~/.profile, which is not a registration candidate. This
+            # assertion is a text lint and proves only that the names are
+            # referenced -- the behavioural proof that the two are actually
+            # inverse is the round-trip Describe below, which is what this one
+            # failed to catch.
             $init      = (Get-Command Invoke-TerminalStylesShellInit).ScriptBlock.ToString()
             $uninstall = (Get-Command Invoke-TerminalStylesUninstall).ScriptBlock.ToString()
             $init      | Should -Match 'Get-ShellRcCandidate'
-            $uninstall | Should -Match 'Get-ShellRcCandidate'
+            $init      | Should -Match 'Get-ShellRcRemovalCandidate'
+            $uninstall | Should -Match 'Get-ShellRcRemovalCandidate'
+        }
+
+        It 'the removal list is a superset of the registration list, plus ~/.profile' {
+            $h = Join-Path $TestDrive ([guid]::NewGuid().ToString('n'))
+            New-Item -ItemType Directory -Path $h -Force | Out-Null
+
+            $reg = @((Get-ShellRcCandidate        -HomeDir $h).Path)
+            $rem = @((Get-ShellRcRemovalCandidate -HomeDir $h).Path)
+
+            foreach ($p in $reg) {
+                $rem | Should -Contain $p -Because 'anything written must be sweepable'
+            }
+            $rem | Should -Contain (Join-Path $h '.profile') `
+                -Because 'shell-init registers there when it is the only file login bash reads'
         }
 
         It 'Get-ShellRcCandidate covers zsh and both bash rc files' {
@@ -237,6 +263,83 @@ Describe 'shell-init and uninstall agree on where the loader lives' {
             ($paths | Where-Object { $_ -like '*.zshrc' })        | Should -Not -BeNullOrEmpty
             ($paths | Where-Object { $_ -like '*.bashrc' })       | Should -Not -BeNullOrEmpty
             ($paths | Where-Object { $_ -like '*.bash_profile' }) | Should -Not -BeNullOrEmpty
+        }
+    }
+}
+
+Describe 'shell-init and shell-remove are actually inverse -- measured, not linted' {
+    # The lint above ("both walk Get-ShellRcCandidate") passed for the whole life
+    # of this bug. Sharing a helper name proves nothing about behaviour: shell-init
+    # registers into ~/.profile in two branches, ~/.profile was not on the list
+    # removal walked, and so `tstyles shell-remove` printed "removed from
+    # ~/.bashrc" and "Open a new tab to get your original prompt back" while the
+    # block stayed in the one file the login shell actually reads. After
+    # `tstyles uninstall` it pointed at a deleted data root, forever, with nothing
+    # left on the machine that could remove it.
+    #
+    # So do not ask what the source says. Run init, run remove, and count the
+    # markers left on disk -- across every rc layout that reaches a different
+    # branch of shell-init.
+    InModuleScope TerminalStyles {
+
+        It 'leaves no loader block behind for the <label> layout' -ForEach @(
+            @{ label = 'nothing at all';        files = @() }
+            @{ label = '~/.profile only';       files = @('.profile') }
+            @{ label = '.bashrc + ~/.profile';  files = @('.bashrc', '.profile') }
+            @{ label = '.bashrc only';          files = @('.bashrc') }
+            @{ label = '.zshrc only';           files = @('.zshrc') }
+            @{ label = 'bashrc + bash_profile'; files = @('.bashrc', '.bash_profile') }
+        ) {
+            $h = Join-Path $TestDrive ([guid]::NewGuid().ToString('n'))
+            New-Item -ItemType Directory -Path $h -Force | Out-Null
+            foreach ($f in $files) {
+                [System.IO.File]::WriteAllText((Join-Path $h $f), "# original $f`n",
+                    [System.Text.UTF8Encoding]::new($false))
+            }
+
+            # Pin $env:SHELL: the "nothing existed" fallback picks its target from
+            # it, so an ambient value would make this depend on the machine.
+            $prev = $env:SHELL
+            try {
+                $env:SHELL = '/bin/bash'
+                Invoke-TerminalStylesShellInit -HomeDir $h -Force          *> $null
+                Invoke-TerminalStylesShellInit -HomeDir $h -Remove         *> $null
+            } finally { $env:SHELL = $prev }
+
+            $left = @(Get-ChildItem -LiteralPath $h -File -Force -ErrorAction SilentlyContinue |
+                Where-Object {
+                    [System.IO.File]::ReadAllText($_.FullName,
+                        [System.Text.UTF8Encoding]::new($false)) -match 'TerminalStyles BEGIN'
+                } | ForEach-Object { $_.Name })
+
+            $left -join ', ' | Should -BeNullOrEmpty `
+                -Because "shell-remove reported success, so nothing may still source the runtime (left in: $($left -join ', '))"
+        }
+
+        It 'gives the user back the file it found, for the <label> layout' -ForEach @(
+            @{ label = '~/.profile only';      files = @('.profile') }
+            @{ label = '.bashrc + ~/.profile'; files = @('.bashrc', '.profile') }
+        ) {
+            # Removing the block must not take the user's own lines with it.
+            $h = Join-Path $TestDrive ([guid]::NewGuid().ToString('n'))
+            New-Item -ItemType Directory -Path $h -Force | Out-Null
+            foreach ($f in $files) {
+                [System.IO.File]::WriteAllText((Join-Path $h $f), "# original $f`nexport MINE=1`n",
+                    [System.Text.UTF8Encoding]::new($false))
+            }
+
+            $prev = $env:SHELL
+            try {
+                $env:SHELL = '/bin/bash'
+                Invoke-TerminalStylesShellInit -HomeDir $h -Force  *> $null
+                Invoke-TerminalStylesShellInit -HomeDir $h -Remove *> $null
+            } finally { $env:SHELL = $prev }
+
+            foreach ($f in $files) {
+                $text = [System.IO.File]::ReadAllText((Join-Path $h $f),
+                    [System.Text.UTF8Encoding]::new($false))
+                $text | Should -Match 'export MINE=1' -Because "$f was the user's file first"
+            }
         }
     }
 }


### PR DESCRIPTION
Found by an adversarial audit — two independent lenses reported it, 0 of 3 verifiers refuted, and I reproduced it before fixing.

## The bug

`shell-init` registers into `~/.profile` in two branches, because in that layout it is the only file the login shell will read and creating a `.bash_profile` would shadow a file already in use.

`~/.profile` is deliberately **not** a registration candidate — it is sh's file rather than bash's, and writing to it unasked would reach past the shells this tool claims. Removal walked that same registration list, so it never looked at the file init had just written to:

```
shell-init   -> added ~/.bashrc, added ~/.profile
shell-remove -> "removed from ~/.bashrc"
                "Open a new tab to get your original prompt back."
left in ~/.profile: 1
```

The message is false in the way that matters: `~/.profile` is the file the login shell reads, so the loader the user was told was gone is **the only one still running**. After `tstyles uninstall` it points at a data root that has just been deleted — on every login shell, permanently, with nothing left on the machine able to remove it and nothing that ever said it was there.

## The fix

Removal walks `Get-ShellRcRemovalCandidate`: the registration list plus `~/.profile`. **Write the narrow set, sweep the wide one.** `Unregister-ShellLoader` returns `'none'` for a file with no block and never creates a file that does not exist, so the extra entry is free wherever it was never used.

## The test that should have caught it

There was one. It asserted that `shell-init` and `uninstall` both *mention* `Get-ShellRcCandidate`:

```powershell
$init      | Should -Match 'Get-ShellRcCandidate'
$uninstall | Should -Match 'Get-ShellRcCandidate'
```

Sharing a helper name is not symmetry, and that lint passed for the entire life of the bug. Replaced with a behavioural round-trip over six rc layouts — run init, run remove, count the markers left on disk — plus a separate assertion that the user's own lines came back. Mutation-checked: reverting the fix turns the `~/.profile`-only and `.bashrc + ~/.profile` layouts red, naming the file left behind.

## Provenance

**This predates the `~/.profile` registration I added for #9 in 0.8.21.** I verified that: `51f401e` already had one `$dotProfile` registration — the `.bashrc`-exists branch — and it orphans identically. My change added a second route into an existing hole, and I should have tested the inverse when I made it. The round-trip covers both branches.

## Verification

1435 passed, 0 failed. Shell tests write to real rc paths, so I checksummed `~/.zshrc`, `~/.bashrc`, `~/.bash_profile` and `~/.profile` before and after — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fc4mE7gSHoux5wL6VEo59S