### PR TITLE
fix(delete): trash was swept on the style's edit time, not its deletion time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **a deleted style could be swept from the trash seconds after `tstyles delete` promised to keep it for seven days.** The sweep in `Move-StyleDirectoryToTrash` asked `$old.LastWriteTime` how long a folder had been in the trash, but the delete is a `Move-Item` within the data root -- a rename, which does not touch a directory's `LastWriteTime`. So the value it read was when the STYLE was last EDITED, which is the one thing it cannot be. A style tuned once and left alone for a month arrived in the trash already three weeks past the cutoff, and the next `tstyles delete` of any style removed it on the spot, having just printed "Kept for 7 days at ...". The window was shortest for exactly the styles least likely to exist anywhere else: a style edited today got the full seven days, one untouched for a month got none, and nothing about the failure was visible until the user went looking for a style they had been told was recoverable.
+
+  `Get-StyleDeletePlan` already stamps the trash folder name with the deletion time (`<name>-yyyyMMdd-HHmmss`), so the correct answer was on disk the whole time and is now read from there. Taking it from the name rather than re-stamping the moved folder also keeps the sweep from ever WRITING to a trashed item: setting `LastWriteTime` would follow a symlinked style directory and modify the link's target, which is the case `Move-StyleDirectoryToTrash` moves-as-a-link specifically to avoid. A folder whose name carries no stamp -- trash from before this, or a folder another hand put there -- still falls back to `LastWriteTime`, so nothing becomes unsweepable.
+
+  `Move-StyleDirectoryToTrash` had no test of any kind; it was one of twelve functions in the module with no test naming them, and the only destructive one among them.
+
 ## [0.8.22] - 2026-09-05
 
 ### Fixed

--- a/lib/deletestyle.ps1
+++ b/lib/deletestyle.ps1
@@ -362,6 +362,56 @@ function Show-StyleDeletePlan {
     Write-Host ""
 }
 
+function Get-StyleTrashTimestamp {
+    <#
+    .SYNOPSIS
+    When was this trashed style deleted? Read from its folder name, not its
+    LastWriteTime.
+
+    .DESCRIPTION
+    The sweep used $old.LastWriteTime as the deletion time. Move-Item renames
+    within the data root, and a rename does not touch the directory's
+    LastWriteTime -- so that timestamp is when the STYLE was last edited, which
+    is the one thing it cannot be. A style tuned once and left alone for a month
+    arrived in the trash already a month stale, and the next `tstyles delete` of
+    any style swept it on the spot, seconds after "Kept for 7 days at ..." said
+    otherwise. The longer a style had gone untouched -- the better the reason to
+    want it back -- the less of the promised window it actually got, and a style
+    edited today got the full seven days.
+
+    Get-StyleDeletePlan already stamps the trash folder name with the deletion
+    time (`<name>-yyyyMMdd-HHmmss`), so the answer was on disk the whole time.
+    Reading it from the name also means the sweep never has to WRITE to the
+    trashed item to keep its own clock: stamping LastWriteTime would follow a
+    symlinked style dir and modify the link's target, the exact thing
+    Move-StyleDirectoryToTrash moves-as-a-link to avoid.
+
+    Anything whose name does not carry a stamp -- trash from before this, or a
+    folder some other hand put there -- falls back to LastWriteTime, which is
+    the previous behaviour rather than a folder that can never be swept.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Name,
+        [Parameter(Mandatory)][datetime]$Fallback
+    )
+
+    # [regex]::Match rather than -match: the automatic $Matches is shared state,
+    # and the suite has already been bitten once by code that wrote to it.
+    $m = [regex]::Match($Name, '-(\d{8})-(\d{6})$')
+    if ($m.Success) {
+        $parsed = [datetime]::MinValue
+        if ([datetime]::TryParseExact(($m.Groups[1].Value + $m.Groups[2].Value),
+                                      'yyyyMMddHHmmss',
+                                      [cultureinfo]::InvariantCulture,
+                                      [System.Globalization.DateTimeStyles]::None,
+                                      [ref]$parsed)) {
+            return $parsed
+        }
+    }
+    return $Fallback
+}
+
 function Move-StyleDirectoryToTrash {
     <#
     .SYNOPSIS
@@ -388,7 +438,8 @@ function Move-StyleDirectoryToTrash {
     if (Test-Path -LiteralPath $trashRoot) {
         $cutoff = (Get-Date).AddDays(-$KeepDays)
         foreach ($old in @(Get-ChildItem -LiteralPath $trashRoot -Directory -Force -ErrorAction SilentlyContinue)) {
-            if ($old.LastWriteTime -ge $cutoff) { continue }
+            $deletedAt = Get-StyleTrashTimestamp -Name $old.Name -Fallback $old.LastWriteTime
+            if ($deletedAt -ge $cutoff) { continue }
             if (-not (Test-PathIsStyleDirChild -Path $old.FullName -Root $trashRoot)) { continue }
             try {
                 if ($old.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {

--- a/tests/Delete-Style.Tests.ps1
+++ b/tests/Delete-Style.Tests.ps1
@@ -333,3 +333,103 @@ Describe 'the SPLIT-root layout is not proof of ownership either' {
         }
     }
 }
+
+# The trash sweep's clock. `tstyles delete` prints "Kept for 7 days at ..." and
+# `tstyles delete` with no name repeats it, but the sweep asked
+# $old.LastWriteTime how old a trashed style was. Move-Item renames within the
+# data root and a rename does not touch a directory's LastWriteTime, so that
+# value is when the style was last EDITED. A style tuned once and left alone for
+# a month landed in the trash already a month past the cutoff and the next
+# delete swept it -- the promised week spent before the user could act on it,
+# and shortest for exactly the styles they were least likely to have a copy of.
+Describe 'the trash sweep measures time since deletion, not since the style was edited' {
+    InModuleScope TerminalStyles {
+        BeforeEach {
+            $script:savedData   = $script:TStylesDataRoot
+            $script:savedModule = $script:TStylesModuleRoot
+            $script:root = Join-Path $TestDrive ([guid]::NewGuid().ToString('n'))
+            $script:TStylesDataRoot   = $script:root
+            $script:TStylesModuleRoot = $script:root
+            script:New-Style $script:root 'eva'  | Out-Null
+            script:New-Style $script:root 'mine' -Tuned | Out-Null
+            [System.IO.File]::WriteAllText((Join-Path $script:root '.installed-files'), "styles/eva`n")
+        }
+        AfterEach {
+            $script:TStylesDataRoot   = $script:savedData
+            $script:TStylesModuleRoot = $script:savedModule
+        }
+
+        Context 'Get-StyleTrashTimestamp' {
+            It 'reads the deletion time out of the trash folder name' {
+                Get-StyleTrashTimestamp -Name 'mine-20260401-131415' -Fallback (Get-Date).AddDays(-30) |
+                    Should -Be ([datetime]::new(2026, 4, 1, 13, 14, 15))
+            }
+
+            It 'reads the stamp this tool appended, not digits inside the style name' {
+                # A user may name a style 'solarized-2024'. The pattern is
+                # anchored at the end, so the trailing stamp is the one read.
+                Get-StyleTrashTimestamp -Name 'solarized-2024-20260401-131415' -Fallback (Get-Date) |
+                    Should -Be ([datetime]::new(2026, 4, 1, 13, 14, 15))
+            }
+
+            It 'falls back for a name carrying no stamp' {
+                # Trash written before this existed, or a folder some other hand
+                # put there. Falling back is the previous behaviour; returning
+                # something far-future would make it unsweepable forever.
+                $fb = [datetime]::new(2020, 1, 2, 3, 4, 5)
+                Get-StyleTrashTimestamp -Name 'no-stamp-here' -Fallback $fb | Should -Be $fb
+            }
+
+            It 'falls back when the stamp is the right shape but not a real date' {
+                $fb = [datetime]::new(2020, 1, 2, 3, 4, 5)
+                Get-StyleTrashTimestamp -Name 'x-20261345-996655' -Fallback $fb | Should -Be $fb
+            }
+        }
+
+        Context 'the sweep itself' {
+            It 'keeps a style deleted seconds ago that had not been edited in a month' {
+                # The regression. Ages the style the way an untouched tuned
+                # style really is, then deletes it and runs the sweep by
+                # deleting a second one.
+                $aged = Get-StyleDir -StyleName 'mine'
+                (Get-Item -LiteralPath $aged).LastWriteTime = (Get-Date).AddDays(-30)
+
+                $plan = Get-StyleDeletePlan -Name 'mine'
+                $plan.Ok | Should -BeTrue
+                Move-StyleDirectoryToTrash -Plan $plan
+                Test-Path -LiteralPath $plan.TrashPath | Should -BeTrue
+
+                script:New-Style $script:root 'second' -Tuned | Out-Null
+                Move-StyleDirectoryToTrash -Plan (Get-StyleDeletePlan -Name 'second')
+
+                Test-Path -LiteralPath $plan.TrashPath |
+                    Should -BeTrue -Because 'it was deleted seconds ago, whatever its LastWriteTime says'
+            }
+
+            It 'sweeps trash whose stamp really is past the window' {
+                # The other direction: this folder was created just now, so its
+                # LastWriteTime is fresh and the old clock would have kept it.
+                # The stamp is what makes it old.
+                $trashRoot = Get-StyleTrashRoot
+                $ancient = Join-Path $trashRoot 'ancient-20200101-000000'
+                New-Item -ItemType Directory -Path $ancient -Force | Out-Null
+
+                Move-StyleDirectoryToTrash -Plan (Get-StyleDeletePlan -Name 'mine')
+
+                Test-Path -LiteralPath $ancient |
+                    Should -BeFalse -Because 'its name says it was deleted in 2020'
+            }
+
+            It 'keeps trash inside the window' {
+                $trashRoot = Get-StyleTrashRoot
+                $stamp  = (Get-Date).AddDays(-2).ToString('yyyyMMdd-HHmmss')
+                $recent = Join-Path $trashRoot "recent-$stamp"
+                New-Item -ItemType Directory -Path $recent -Force | Out-Null
+
+                Move-StyleDirectoryToTrash -Plan (Get-StyleDeletePlan -Name 'mine')
+
+                Test-Path -LiteralPath $recent | Should -BeTrue -Because '2 days is inside the 7-day window'
+            }
+        }
+    }
+}


### PR DESCRIPTION
## The defect

`tstyles delete` moves a style aside and prints:

```
  Deleted mine.
  Kept for 7 days at .../.deleted/mine-20260905-020339
```

The sweep in `Move-StyleDirectoryToTrash` decided a trashed folder's age from `$old.LastWriteTime`. But the delete is a `Move-Item` **within the data root** — a rename, and a rename does not touch a directory's `LastWriteTime`. So the value being read is when the *style was last edited*, which is the one thing it cannot be.

Measured on this machine:

```
before move : 06/08/2026 2:00:25 AM
after  move : 06/08/2026 2:00:25 AM      <- unchanged by the move
cutoff (7d) : 29/08/2026 2:00:25 AM
swept immediately? True
```

So a style tuned once and left alone for a month arrives in the trash already three weeks past the cutoff, and the **next `tstyles delete` of any style removes it** — seconds after the message promised a week. The retention window was shortest for exactly the styles least likely to exist anywhere else: a style edited today got the full seven days, one untouched for a month got none. Nothing about the failure was visible until the user went looking for a style they had been told was recoverable.

## The fix

The deletion time was already on disk. `Get-StyleDeletePlan` stamps the trash folder name `<name>-yyyyMMdd-HHmmss`, so `Get-StyleTrashTimestamp` reads it from there.

Reading the name rather than re-stamping the moved folder is deliberate: setting `LastWriteTime` on the trashed item would follow a **symlinked** style directory and modify the link's *target* — precisely the case `Move-StyleDirectoryToTrash` moves-as-a-link to avoid. This way the sweep never writes to a trashed item to keep its own clock.

A folder whose name carries no stamp — trash from before this, or a folder another hand put there — still falls back to `LastWriteTime`, so nothing becomes unsweepable.

## Tests

`Move-StyleDirectoryToTrash` had **no test of any kind**. It was one of twelve functions in the module with no test naming them, and the only destructive one among them.

Added seven, four unit and three behavioural. The regression test ages a style 30 days, deletes it, then triggers the sweep with a second delete. Confirmed it fails on the old code:

```
[-] keeps a style deleted seconds ago that had not been edited in a month
 Expected $true, because it was deleted seconds ago, whatever its
 LastWriteTime says, but got $false.
```

The reverse case is covered too — a folder created just now but *stamped* 2020 is swept, which the old clock would have kept — along with the fallback for unstamped names and a stamp-shaped string that is not a real date.

Full suite locally: **1444 passed, 0 failed** (run with `HOME` pointed at a scratch dir so it could not reach real rc files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHfeNid3QAWZENXUCYzfjv