### PR TITLE
fix(uninstall): the $PROFILE half never got the fixes the rc half did

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`tstyles uninstall` silently corrupted a `$PROFILE` that contained a byte which is not valid UTF-8, and took no backup on the way out.** Step 3 of uninstall reads the whole of the user's `$PROFILE` and writes the whole of it back, exactly as the rc half does -- and it did so through UTF-8. `Get-RcFileEncoding` exists because of what that costs, and its own docstring spells it out: a latin-1 comment or a stray byte from an old editor decodes to U+FFFD and is written back as the replacement character, so "the user's own content, silently and permanently corrupted, by a tool that was only asked to append three lines". That was fixed for `.zshrc` and `.bashrc`; the `$PROFILE` half was a second, open-coded copy of the same removal and never got it. Measured on a profile whose first line was `# café`, byte `e9`:
+
+  ```
+  before : 23 20 63 61 66 e9 0a ...
+  after  : 23 20 63 61 66 ef bf bd ...      # U+FFFD
+  ```
+
+  Removal is also the one path with no safety net: `Save-FirstTouchBackup` is deliberately FIRST TOUCH, so it skips a file that already carries our block -- which every file uninstall touches does, by definition. `tstyles register` had the same UTF-8 on the same file and is fixed with it; there the first-touch backup is a byte-level `Copy-Item` and so was itself intact.
+
+- **an uninstall could not say that it had failed to remove the loader from a `$PROFILE`, and in one case died in the middle of the command.** The same open-coded copy had none of the three statuses `Unregister-ShellLoader` reports. A `$PROFILE` carrying a BEGIN with no matching END left the content unchanged, so nothing was written AND nothing was printed -- while the command signed off with "Open a new pwsh tab to confirm the loader is gone", which was the opposite of the truth, about a block still sourcing a data root `-DeleteData` may have just deleted. The rc half prints that one in red and tells the user to remove it by hand. And the write was unguarded: a read-only `$PROFILE` -- the nix or chezmoi store case `Unregister-ShellLoader`'s docstring names explicitly -- threw out of the middle of `Invoke-TerminalStylesUninstall`, after step 1 had removed the module and step 2 had stripped the rc files, and before step 4 ran at all.
+
+  The strip no longer re-derives any of this: it calls `Unregister-ShellLoader`, the one implementation that already learned all three, and reports each status the way `tstyles shell-remove` does.
+
+### Changed
+
+- uninstall's `$PROFILE` half is testable for the first time. Its paths come from RUNNING each engine (`& $cmd.Source -Command 'Write-Output $PROFILE'`), so the only profile any test could reach was the one belonging to whoever was running the suite -- which is why none of the three defects above was ever caught, the same shape as the rc omission fixed in 0.8.23. Discovery is now `Get-PowerShellProfileTarget` and the strip is `Remove-PowerShellProfileLoader -Target`, an internal injection of the same shape and purpose as `Invoke-TerminalStylesRegister -Targets`; nothing in the new tests goes near a real `$PROFILE`.
+- uninstall no longer processes one `$PROFILE` twice. `pwsh` and `pwsh-preview` report the same path on a macOS machine that has both, so a malformed or unwritable profile would now have printed its warning once per engine for a single file. Windows' two engines keep separate directories and nothing merges there.
+- the test that was supposed to guarantee uninstall used the shared engine probe asserted that the text of `Invoke-TerminalStylesUninstall` contained the string `Get-PowerShellEngineCandidate`. That is the same kind of test 0.8.22 already caught being worthless once -- "sharing a helper name is not symmetry, and it passed for the whole life of the bug" -- and it broke on a refactor that moved the call without changing a single behaviour. It now follows the discovery function, asserts that the caller actually reaches it, and checks behaviourally that every discovered target carries a label the probe issued.
+
 ## [0.8.23] - 2026-09-07
 
 ### Fixed

--- a/lib/update.ps1
+++ b/lib/update.ps1
@@ -185,6 +185,14 @@ function Invoke-TerminalStylesRegister {
     $loaderBegin = '# ===== TerminalStyles BEGIN ====='
     $loaderEnd   = '# ===== TerminalStyles END ====='
 
+    # Get-RcFileEncoding, not UTF-8, for the reason its docstring gives: this
+    # reads the WHOLE of a file the user owns and writes the WHOLE of it back,
+    # so a byte that is not valid UTF-8 -- a latin-1 comment, a stray byte from
+    # an old editor -- decoded to U+FFFD and was written back as the
+    # replacement character. That was fixed for rc files and the $PROFILE half
+    # never got it. ISO-8859-1 round-trips every byte 0-255 unchanged, and the
+    # markers and the loader line are ASCII either way.
+
     # By NAME only when the module is somewhere PowerShell will look. A
     # bootstrap install is not on $env:PSModulePath -- which is exactly why
     # install.ps1 writes the full-path form, and why Get-ShellRcCandidate's
@@ -258,7 +266,7 @@ $loaderEnd
     $blockPattern = "(?ms)$([regex]::Escape($loaderBegin)).*?$([regex]::Escape($loaderEnd))\r?\n?"
     foreach ($t in $targets) {
         if ($t.Exists) {
-            $content = [System.IO.File]::ReadAllText($t.ProfilePath, [System.Text.UTF8Encoding]::new($false))
+            $content = [System.IO.File]::ReadAllText($t.ProfilePath, (Get-RcFileEncoding))
             $t.HasLoader = ($content -match $blockPattern)
         }
     }
@@ -306,7 +314,7 @@ $loaderEnd
         }
 
         $existing = if ($t.Exists) {
-            [System.IO.File]::ReadAllText($t.ProfilePath, [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::ReadAllText($t.ProfilePath, (Get-RcFileEncoding))
         } else { '' }
 
         if ($existing -match $blockPattern) {
@@ -319,7 +327,7 @@ $loaderEnd
         # hand-maintained profile with no copy kept.
         $bak = Save-FirstTouchBackup -Path $t.ProfilePath -Content $existing -BlockPattern ([regex]::Escape($loaderBegin))
         if ($bak) { Write-Host "  Backed up your existing $($t.Label) profile to: $bak" -ForegroundColor Gray }
-        [System.IO.File]::WriteAllText($t.ProfilePath, $final, [System.Text.UTF8Encoding]::new($false))
+        [System.IO.File]::WriteAllText($t.ProfilePath, $final, (Get-RcFileEncoding))
 
         Write-Host "  Registered in $($t.ProfilePath)" -ForegroundColor Green
     }
@@ -404,6 +412,111 @@ function Get-UninstallPlan {
     }
 }
 
+function Get-PowerShellProfileTarget {
+    <#
+    .SYNOPSIS
+    The $PROFILE files of the PowerShell engines present on this machine.
+
+    .DESCRIPTION
+    Pulled out of Invoke-TerminalStylesUninstall so the strip below can be run
+    against a sandbox. It could not be before: the paths come from RUNNING each
+    engine, so the only $PROFILE any test could reach was the one belonging to
+    the operator, and step 3 was therefore never exercised by anything. That is
+    the same reason the rc half's omission went four releases unnoticed, and the
+    same seam Invoke-TerminalStylesRegister already carries as -Targets.
+
+    Only files that exist: a $PROFILE that was never created has no block in it.
+
+    Distinct by path. Two engines can share one $PROFILE -- on this machine
+    `pwsh` and `pwsh-preview` both report
+    ~/.config/powershell/Microsoft.PowerShell_profile.ps1 -- and processing it
+    twice would print the malformed and unwritable warnings twice for one file.
+    Windows' two engines keep separate directories, so nothing merges there.
+    #>
+    [CmdletBinding()]
+    param()
+
+    $seen = @{}
+    @(foreach ($e in (Get-PowerShellEngineCandidate)) {
+        $cmd = Get-Command -Name $e.Exe -ErrorAction SilentlyContinue
+        if (-not $cmd) { continue }
+        $profilePath = & $cmd.Source -NoProfile -NonInteractive -Command 'Write-Output $PROFILE' 2>$null
+        if (-not $profilePath) { continue }
+        $profilePath = $profilePath.Trim()
+        if (-not (Test-Path -LiteralPath $profilePath)) { continue }
+        if ($seen.ContainsKey($profilePath)) { continue }
+        $seen[$profilePath] = $true
+        [pscustomobject]@{ ProfilePath = $profilePath; Label = $e.Label }
+    })
+}
+
+function Remove-PowerShellProfileLoader {
+    <#
+    .SYNOPSIS
+    Strip the loader block from each engine's $PROFILE. Returns how many went.
+
+    .DESCRIPTION
+    This was a second, open-coded implementation of Unregister-ShellLoader, and
+    it never received any of the three fixes that one did. A $PROFILE is a file
+    the USER owns and that predates us, exactly like an rc file, and uninstall
+    reads the whole of it and writes the whole of it back:
+
+      * It read and wrote through UTF-8. Get-RcFileEncoding is ISO-8859-1
+        precisely because that round-trips every byte 0-255 unchanged, and its
+        own docstring describes what UTF-8 does instead: a latin-1 comment or a
+        stray byte from an old editor decodes to U+FFFD and is written back as
+        the replacement character. Measured on a $PROFILE whose first line was
+        `# caf\xe9`: the byte e9 came back as ef bf bd, permanently, from a
+        command that was only asked to remove three lines -- and unlike the
+        register path, removal takes no backup, because the FIRST TOUCH rule
+        deliberately skips a file that already carries our block.
+      * A BEGIN with no matching END left the string unchanged, so nothing was
+        written AND nothing was said, while the command signed off with "Open a
+        new pwsh tab to confirm the loader is gone." Unregister-ShellLoader
+        calls that 'malformed' and the rc half prints it in red.
+      * The write was unguarded. A read-only $PROFILE -- the nix or chezmoi
+        store case Unregister-ShellLoader's own docstring names -- threw out of
+        the middle of uninstall, after the module and the rc blocks were
+        already gone and before the user-state step ran. The rc half calls that
+        'failed', says so, and carries on.
+
+    So it does not re-derive any of that: it calls Unregister-ShellLoader, and
+    reports each status the way Invoke-TerminalStylesShellInit -Remove does.
+
+    -Target is an internal/test injection of {ProfilePath, Label} objects, the
+    same shape and the same purpose as Invoke-TerminalStylesRegister -Targets.
+    Real callers omit it and get Get-PowerShellProfileTarget.
+    #>
+    [CmdletBinding()]
+    param([object[]]$Target)
+
+    if (-not $PSBoundParameters.ContainsKey('Target')) {
+        $Target = @(Get-PowerShellProfileTarget)
+    }
+
+    $removed = 0
+    foreach ($t in $Target) {
+        switch (Unregister-ShellLoader -Path $t.ProfilePath) {
+            'removed' {
+                Write-Host "  Removed loader from $($t.ProfilePath)" -ForegroundColor Green
+                $removed++
+            }
+            'malformed' {
+                Write-Host ("  ! {0} has a TerminalStyles BEGIN marker with no matching END." -f $t.ProfilePath) -ForegroundColor Red
+                Write-Host "    Nothing was removed. Delete the block by hand -- it still loads on every tab." -ForegroundColor Red
+            }
+            'failed' {
+                Write-Host ("  ! could not write {0}" -f $t.ProfilePath) -ForegroundColor Red
+                Write-Host "    The loader is still there. Check the file's permissions (a read-only" -ForegroundColor Red
+                Write-Host "    profile, or one managed by nix or chezmoi) and remove the block by hand." -ForegroundColor Red
+            }
+            # 'none' is the ordinary case for an engine that was never
+            # registered, and says nothing on purpose.
+        }
+    }
+    return $removed
+}
+
 function Invoke-TerminalStylesUninstall {
     [CmdletBinding()]
     param(
@@ -418,12 +531,19 @@ function Invoke-TerminalStylesUninstall {
         # ~/.zshrc. Forwarded by what the caller BOUND, the rule
         # Get-ShellRcCandidate documents.
         [string]$HomeDir,
-        [string]$ZDotDir
+        [string]$ZDotDir,
+        # The same kind of seam for the $PROFILE half, which resolves its paths
+        # by RUNNING each engine and so otherwise reaches only the operator's
+        # own profile. Same shape as Invoke-TerminalStylesRegister -Targets.
+        [object[]]$ProfileTarget
     )
 
     $rcSplat = @{}
     if ($PSBoundParameters.ContainsKey('HomeDir')) { $rcSplat.HomeDir = $HomeDir }
     if ($PSBoundParameters.ContainsKey('ZDotDir')) { $rcSplat.ZDotDir = $ZDotDir }
+
+    $profileSplat = @{}
+    if ($PSBoundParameters.ContainsKey('ProfileTarget')) { $profileSplat.Target = $ProfileTarget }
 
     $dataDir = Get-TStylesDataRoot
     $kind = Get-TerminalStylesInstallKind
@@ -540,21 +660,7 @@ function Invoke-TerminalStylesUninstall {
     }
 
     # 3. Strip the loader from both PowerShell engines' $PROFILE
-    foreach ($exe in (Get-PowerShellEngineCandidate).Exe) {
-        $cmd = Get-Command -Name $exe -ErrorAction SilentlyContinue
-        if (-not $cmd) { continue }
-        $profilePath = & $cmd.Source -NoProfile -NonInteractive -Command 'Write-Output $PROFILE' 2>$null
-        if (-not $profilePath) { continue }
-        $profilePath = $profilePath.Trim()
-        if (-not (Test-Path -LiteralPath $profilePath)) { continue }
-
-        $content = [System.IO.File]::ReadAllText($profilePath, [System.Text.UTF8Encoding]::new($false))
-        $newContent = [regex]::Replace($content, '(?ms)# ===== TerminalStyles BEGIN =====.*?# ===== TerminalStyles END =====\r?\n?', '')
-        if ($newContent -ne $content) {
-            [System.IO.File]::WriteAllText($profilePath, $newContent, [System.Text.UTF8Encoding]::new($false))
-            Write-Host "  Removed loader from $profilePath" -ForegroundColor Green
-        }
-    }
+    Remove-PowerShellProfileLoader @profileSplat | Out-Null
 
     # 4. Optionally remove user state
     if ($DeleteData) {

--- a/tests/Get-PowerShellEngineCandidate.Tests.ps1
+++ b/tests/Get-PowerShellEngineCandidate.Tests.ps1
@@ -109,7 +109,14 @@ Describe 'register and uninstall use the shared probe' {
             # pwsh and pwsh-preview report the same path on a macOS machine that
             # has both; processing it twice would print the malformed and
             # unwritable warnings twice for one file.
-            $paths = @((Get-PowerShellProfileTarget).ProfilePath)
+            #
+            # ForEach-Object, not @((...).ProfilePath): member access on an
+            # EMPTY array yields a single $null rather than nothing, so the
+            # first draft compared 1 against 0 and failed on every CI machine
+            # -- none of which has a $PROFILE file at all. Vacuous where there
+            # are no targets, which is the honest thing for it to be: it cannot
+            # create a $PROFILE to test against without writing to a real one.
+            $paths = @(Get-PowerShellProfileTarget | ForEach-Object { $_.ProfilePath })
             ($paths | Select-Object -Unique).Count | Should -Be $paths.Count
         }
 

--- a/tests/Get-PowerShellEngineCandidate.Tests.ps1
+++ b/tests/Get-PowerShellEngineCandidate.Tests.ps1
@@ -82,11 +82,45 @@ Describe 'register and uninstall use the shared probe' {
             $src | Should -Not -Match "'powershell\.exe'"
         }
 
-        It 'Invoke-TerminalStylesUninstall hardcodes no engine name' {
-            $src = (Get-Command Invoke-TerminalStylesUninstall).ScriptBlock.ToString()
+        It 'the uninstall side hardcodes no engine name' {
+            # Uninstall's $PROFILE discovery lives in Get-PowerShellProfileTarget
+            # now -- pulled out so the strip below it can be run against a
+            # sandbox at all. This assertion follows the discovery rather than
+            # the caller; asserting on Invoke-TerminalStylesUninstall's source
+            # would now pass or fail on where the code sits rather than on what
+            # it does.
+            $src = (Get-Command Get-PowerShellProfileTarget).ScriptBlock.ToString()
             $src | Should -Match 'Get-PowerShellEngineCandidate'
             $src | Should -Not -Match "'pwsh\.exe'"
             $src | Should -Not -Match "'powershell\.exe'"
+        }
+
+        It 'uninstall reaches its $PROFILE discovery' {
+            # The half a source grep cannot see: that the caller still calls it.
+            # Without this the check above is satisfied by a function nothing
+            # runs, which is how a passing suite hid the last two defects here.
+            (Get-Command Invoke-TerminalStylesUninstall).ScriptBlock.ToString() |
+                Should -Match 'Remove-PowerShellProfileLoader'
+            (Get-Command Remove-PowerShellProfileLoader).ScriptBlock.ToString() |
+                Should -Match 'Get-PowerShellProfileTarget'
+        }
+
+        It 'names each $PROFILE once, even when two engines share one' {
+            # pwsh and pwsh-preview report the same path on a macOS machine that
+            # has both; processing it twice would print the malformed and
+            # unwritable warnings twice for one file.
+            $paths = @((Get-PowerShellProfileTarget).ProfilePath)
+            ($paths | Select-Object -Unique).Count | Should -Be $paths.Count
+        }
+
+        It 'every discovered target carries a label from the shared probe' {
+            # Behavioural, not textual: whatever engines this machine has, each
+            # target names one of them.
+            $labels = @((Get-PowerShellEngineCandidate).Label)
+            foreach ($t in @(Get-PowerShellProfileTarget)) {
+                $labels | Should -Contain $t.Label
+                $t.ProfilePath | Should -Not -BeNullOrEmpty
+            }
         }
     }
 }

--- a/tests/Remove-PowerShellProfileLoader.Tests.ps1
+++ b/tests/Remove-PowerShellProfileLoader.Tests.ps1
@@ -127,12 +127,20 @@ Describe 'Remove-PowerShellProfileLoader' {
                 # The nix / chezmoi store case. Unguarded, this threw after the
                 # module and the rc blocks were already gone and before the
                 # user-state step ran.
+                # IsReadOnly rather than chmod: it is one .NET attribute on
+                # every platform the suite runs on, where chmod is an external
+                # binary that happens to be on the Windows runners because Git
+                # for Windows ships it.
                 $t = script:New-Profile 'p.ps1' ([byte[]]@())
-                chmod 444 $t.ProfilePath
+                $f = Get-Item -LiteralPath $t.ProfilePath -Force
+                $f.IsReadOnly = $true
                 try {
-                    { script:Say @($t) } | Should -Not -Throw
+                    { script:Say @($t) } | Should -Not -Throw `
+                        -Because 'it throws out of the middle of an uninstall otherwise'
                     script:Say @($t) | Should -Match 'could not write'
-                } finally { chmod 644 $t.ProfilePath }
+                    [System.IO.File]::ReadAllText($t.ProfilePath) |
+                        Should -Match 'TerminalStyles BEGIN' -Because 'the loader really is still there'
+                } finally { $f.IsReadOnly = $false }
             }
         }
 

--- a/tests/Remove-PowerShellProfileLoader.Tests.ps1
+++ b/tests/Remove-PowerShellProfileLoader.Tests.ps1
@@ -1,0 +1,178 @@
+# Pester 5 tests: uninstall's $PROFILE strip, which was a second, open-coded
+# copy of Unregister-ShellLoader that never received any of the fixes that one
+# did.
+#
+# A $PROFILE is a file the USER owns and that predates us, exactly like an rc
+# file, and uninstall reads the whole of it and writes the whole of it back.
+# Three defects followed from having two implementations of that:
+#
+#   1. ENCODING. It read and wrote through UTF-8. Get-RcFileEncoding is
+#      ISO-8859-1 precisely because that round-trips every byte 0-255
+#      unchanged; UTF-8 decodes a latin-1 comment to U+FFFD and writes the
+#      replacement character back. Measured on a $PROFILE opening with
+#      `# caf\xe9`: byte e9 came back as ef bf bd, permanently -- and removal
+#      takes no backup, because the FIRST TOUCH rule deliberately skips a file
+#      that already carries our block.
+#   2. MALFORMED. A BEGIN with no END left the string unchanged, so nothing was
+#      written AND nothing was said, while the command signed off with "Open a
+#      new pwsh tab to confirm the loader is gone."
+#   3. UNWRITABLE. The write was unguarded, so a read-only $PROFILE threw out of
+#      the middle of uninstall -- after the module and the rc blocks were gone,
+#      before the user-state step ran.
+#
+# None of it was ever exercised, because the paths came from RUNNING each
+# engine: the only $PROFILE a test could reach was the operator's own. That is
+# what -Target is for, and nothing here goes near a real profile.
+#
+# Run: Invoke-Pester -Path tests
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+BeforeDiscovery {
+    $repoRoot = Split-Path $PSScriptRoot -Parent
+    Import-Module (Join-Path $repoRoot 'TerminalStyles.psd1') -Force -DisableNameChecking *> $null
+}
+BeforeAll {
+    $repoRoot = Split-Path $PSScriptRoot -Parent
+    Import-Module (Join-Path $repoRoot 'TerminalStyles.psd1') -Force -DisableNameChecking *> $null
+}
+
+Describe 'Remove-PowerShellProfileLoader' {
+    InModuleScope TerminalStyles {
+        BeforeEach {
+            $script:d = Join-Path $TestDrive ([guid]::NewGuid().ToString('n'))
+            New-Item -ItemType Directory -Path $script:d -Force | Out-Null
+        }
+
+        # Bytes, not a string: the whole point of these tests is what survives
+        # the round trip, and writing the fixture through any encoding at all
+        # would decide the answer before the code under test ran.
+        # Host output only. The function also RETURNS a count, and a bare 6>&1
+        # capture mixes the two -- the first draft asserted on '0' and failed
+        # on output that was correct.
+        function script:Say([object[]]$T) {
+            @(Remove-PowerShellProfileLoader -Target $T 6>&1 |
+              Where-Object { $_ -is [System.Management.Automation.InformationRecord] }) -join "`n"
+        }
+
+        function script:New-Profile([string]$Name, [byte[]]$Lead, [switch]$Malformed) {
+            $p = Join-Path $script:d $Name
+            $body = if ($Malformed) {
+                "# ===== TerminalStyles BEGIN =====`nImport-Module TerminalStyles`n"
+            } else {
+                "# ===== TerminalStyles BEGIN =====`nImport-Module TerminalStyles`n# ===== TerminalStyles END =====`nfunction prompt { 'hi> ' }`n"
+            }
+            [System.IO.File]::WriteAllBytes($p, ([byte[]]$Lead + [System.Text.Encoding]::ASCII.GetBytes($body)))
+            [pscustomobject]@{ ProfilePath = $p; Label = 'PowerShell 7' }
+        }
+
+        Context 'a $PROFILE the user owns' {
+            It 'removes the block and reports it' {
+                $t = script:New-Profile 'p.ps1' ([byte[]]@())
+                script:Say @($t) | Should -Match 'Removed loader from'
+                [System.IO.File]::ReadAllText($t.ProfilePath) | Should -Not -Match 'TerminalStyles BEGIN'
+            }
+
+            It 'keeps the rest of the file' {
+                $t = script:New-Profile 'p.ps1' ([byte[]]@())
+                Remove-PowerShellProfileLoader -Target @($t) 6>&1 | Out-Null
+                [System.IO.File]::ReadAllText($t.ProfilePath) | Should -Match "function prompt"
+            }
+
+            It 'says nothing about a $PROFILE that carries no block' {
+                $p = Join-Path $script:d 'clean.ps1'
+                [System.IO.File]::WriteAllText($p, "# just mine`n")
+                script:Say @([pscustomobject]@{ ProfilePath = $p; Label = 'x' }) |
+                    Should -BeNullOrEmpty -Because "'none' is the ordinary case for an engine never registered"
+                [System.IO.File]::ReadAllText($p) | Should -Be "# just mine`n"
+            }
+        }
+
+        Context 'a byte that is not valid UTF-8' {
+            It 'leaves every other byte in the file exactly as it was' {
+                # 0xE9 -- "e" acute in latin-1, in a comment the user wrote.
+                # Through UTF-8 this came back as ef bf bd, the replacement
+                # character, and there is no backup on the removal path.
+                $t = script:New-Profile 'p.ps1' ([byte[]]@(0x23,0x20,0x63,0x61,0x66,0xE9,0x0A))
+                Remove-PowerShellProfileLoader -Target @($t) 6>&1 | Out-Null
+
+                $after = [System.IO.File]::ReadAllBytes($t.ProfilePath)
+                $after[0..6] | Should -Be ([byte[]]@(0x23,0x20,0x63,0x61,0x66,0xE9,0x0A)) `
+                    -Because 'the user wrote that byte and did not ask us to change it'
+                $after | Should -Not -Contain 0xFD -Because 'ef bf bd is U+FFFD, the corruption'
+            }
+        }
+
+        Context 'a block with BEGIN and no END' {
+            It 'says so loudly instead of silently doing nothing' {
+                # The command signs off with "Open a new pwsh tab to confirm the
+                # loader is gone", so silence here is worse than an error.
+                $t = script:New-Profile 'p.ps1' ([byte[]]@()) -Malformed
+                $out = script:Say @($t)
+
+                $out | Should -Match 'no matching END'
+                $out | Should -Match 'by hand'
+                $out | Should -Not -Match 'Removed loader from'
+            }
+
+            It 'leaves the file alone' {
+                $t = script:New-Profile 'p.ps1' ([byte[]]@()) -Malformed
+                $before = [System.IO.File]::ReadAllBytes($t.ProfilePath)
+                Remove-PowerShellProfileLoader -Target @($t) 6>&1 | Out-Null
+                [System.IO.File]::ReadAllBytes($t.ProfilePath) | Should -Be $before
+            }
+        }
+
+        Context 'a $PROFILE that cannot be written' {
+            It 'reports it and does not throw out of the middle of an uninstall' {
+                # The nix / chezmoi store case. Unguarded, this threw after the
+                # module and the rc blocks were already gone and before the
+                # user-state step ran.
+                $t = script:New-Profile 'p.ps1' ([byte[]]@())
+                chmod 444 $t.ProfilePath
+                try {
+                    { script:Say @($t) } | Should -Not -Throw
+                    script:Say @($t) | Should -Match 'could not write'
+                } finally { chmod 644 $t.ProfilePath }
+            }
+        }
+
+        Context 'the count it returns' {
+            It 'counts only the profiles it really stripped' {
+                $ok   = script:New-Profile 'a.ps1' ([byte[]]@())
+                $bad  = script:New-Profile 'b.ps1' ([byte[]]@()) -Malformed
+                $none = Join-Path $script:d 'c.ps1'
+                [System.IO.File]::WriteAllText($none, "# mine`n")
+
+                $n = Remove-PowerShellProfileLoader -Target @(
+                        $ok, $bad, [pscustomobject]@{ ProfilePath = $none; Label = 'x' }) 6>$null
+                $n | Should -Be 1
+            }
+        }
+    }
+}
+
+Describe 'tstyles register writes a $PROFILE through the same encoding' {
+    InModuleScope TerminalStyles {
+        It 'does not corrupt a byte that is not valid UTF-8' {
+            # register has the same read-whole/write-whole shape, and had the
+            # same UTF-8. It does take a first-touch backup -- Copy-Item, so the
+            # backup itself is fine -- but the live file was still rewritten
+            # with the user's byte replaced.
+            $d = Join-Path $TestDrive ([guid]::NewGuid().ToString('n'))
+            New-Item -ItemType Directory -Path $d -Force | Out-Null
+            $p = Join-Path $d 'profile.ps1'
+            [System.IO.File]::WriteAllBytes($p, [byte[]]@(0x23,0x20,0x63,0x61,0x66,0xE9,0x0A))
+
+            Invoke-TerminalStylesRegister -Yes -Targets @([pscustomobject]@{
+                ProfilePath = $p; Exists = $true; HasLoader = $false; Label = 'PowerShell 7'
+            }) 6>&1 | Out-Null
+
+            # The user's TEXT, not the line terminator: register joins with
+            # "`r`n" by its own design, and that is not what is under test here.
+            $after = [System.IO.File]::ReadAllBytes($p)
+            $after[0..5] | Should -Be ([byte[]]@(0x23,0x20,0x63,0x61,0x66,0xE9))
+            $after | Should -Not -Contain 0xFD -Because 'ef bf bd is U+FFFD, the corruption'
+            [System.IO.File]::ReadAllText($p) | Should -Match 'TerminalStyles BEGIN'
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #17. That PR added a third copy of the loader marker literal, which prompted a look at whether the copies had diverged. They had — and not cosmetically.

## The defect

Step 3 of `tstyles uninstall` is a second, open-coded implementation of `Unregister-ShellLoader`, over a `$PROFILE`, which is a file the **user** owns and that predates us in exactly the way an rc file does. It received none of the three fixes that one did.

### 1. It corrupted the file

It read the whole profile and wrote the whole profile back through UTF-8. `Get-RcFileEncoding` is ISO-8859-1 *precisely* because that round-trips every byte 0–255 unchanged, and its own docstring already says what UTF-8 does instead:

> a single byte that is not valid UTF-8 — a latin-1 comment, a stray byte from an old editor — was decoded to U+FFFD on the first shell-init and written back as the replacement character. The user's own content, silently and permanently corrupted, by a tool that was only asked to append three lines.

That was fixed for `.zshrc` and `.bashrc`. The `$PROFILE` half never got it. Measured on a profile whose first line is `# café`:

```
before : 23 20 63 61 66 e9 0a ...
after  : 23 20 63 61 66 ef bf bd ...      # U+FFFD
```

Removal is also the one path with **no safety net**: `Save-FirstTouchBackup` is deliberately FIRST TOUCH, so it skips a file that already carries our block — which every file uninstall touches does, by definition. `tstyles register` had the same UTF-8 on the same file and is fixed with it; there the backup is a byte-level `Copy-Item` and so was itself intact.

### 2. It could not say it had failed

A `$PROFILE` with a BEGIN and no matching END left the content unchanged, so **nothing was written and nothing was printed** — while the command signs off with:

> Open a new pwsh tab to confirm the loader is gone.

which is the opposite of the truth, about a block still sourcing a data root `-DeleteData` may have just deleted. `Unregister-ShellLoader` calls that `'malformed'` and the rc half prints it in red.

### 3. It died in the middle of the command

The write was unguarded. A read-only `$PROFILE` — the nix or chezmoi store case `Unregister-ShellLoader`'s docstring names explicitly — threw out of the middle of `Invoke-TerminalStylesUninstall`: after step 1 removed the module and step 2 stripped the rc files, before step 4 ran at all. The rc half calls that `'failed'`, says so, and carries on.

## Why nothing caught it

The `$PROFILE` paths come from **running** each engine (`& $cmd.Source -Command 'Write-Output $PROFILE'`), so the only profile a test could reach was the one belonging to whoever ran the suite. Step 3 was therefore never exercised by anything — the same shape as the rc omission fixed in 0.8.23.

## The fix

The strip no longer re-derives any of it: it calls `Unregister-ShellLoader`, the one implementation that already learned all three, and reports each status the way `tstyles shell-remove` does. Discovery is `Get-PowerShellProfileTarget`, the strip is `Remove-PowerShellProfileLoader -Target` — the same internal injection shape `Invoke-TerminalStylesRegister -Targets` already carries. Nothing in the new tests goes near a real `$PROFILE`.

Targets are also distinct by path now: `pwsh` and `pwsh-preview` report the same profile on a macOS machine with both, so a malformed file would have printed its warning twice.

## One test replaced

`Invoke-TerminalStylesUninstall hardcodes no engine name` asserted that the function's **source text** contained the string `Get-PowerShellEngineCandidate`. That is the same worthless shape 0.8.22 already caught once — *"sharing a helper name is not symmetry, and it passed for the whole life of the bug"* — and it broke here on a refactor that moved a call without changing a single behaviour. It now follows the discovery function, asserts the caller actually reaches it, and checks behaviourally that every discovered target carries a label the probe issued.

## Verification

Full suite green locally: **1480 passed, 11 skipped**.

Honest note on binding: the register-encoding test binds precisely — reverting only those three encoding sites fails exactly that one test and nothing else. The eight uninstall tests fail without the fix, but partly because the function under test is new, so the real evidence for those is the measurement above, taken by running the old lines verbatim against crafted files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4UptB5S567PxKmMdyH8T1
