### PR TITLE
fix(uninstall): restore $wezSplat, lost in a merge, and guard the whole class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ Thumbs.db
 
 # Staging dir for PSGallery publish (scripts/publish.ps1)
 out/
+
+# Agent worktrees, created by tooling. Never part of the project.
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`tstyles uninstall` threw before it could ask for consent, on any machine, because two lines were lost in a merge.** `$wezSplat = @{}` and the `ContainsKey('HomeDir')` line beside it were dropped resolving the merge between the WezTerm writer and the `$PROFILE`-strip change -- both touched the same few lines at the top of `Invoke-TerminalStylesUninstall` -- while both USES of `@wezSplat` survived further down. `main` went red on the merge commit.
+
+  The mechanism is worth recording, because it is the opposite of what everything in this project assumes. PowerShell does not object to splatting a variable that does not exist, and it does not pass "no arguments" either:
+
+  ```
+  function Probe { param([string]$HomeDir) ... }
+  Probe @neverDefined   ->   bound=True   value=[]
+  ```
+
+  It binds the FIRST POSITIONAL parameter to an empty string, and `$PSBoundParameters.ContainsKey('HomeDir')` reports `$true`. That `ContainsKey` test is the guard this codebase uses everywhere to tell "the caller asked for a sandbox" from "use the live `$HOME`" -- so a lost splat definition does not turn the seam off, it announces a sandbox at the empty path. It fails unsafe. Here it happened to throw on `Join-Path`, which is why five tests went red rather than something quietly resolving against the wrong home; that was luck.
+
+  `tests/Splat-Variables-Defined.Tests.ps1` now walks the AST of every source file and fails if any scope splats a variable it never assigns. It names the offending function and variable, and it catches this exact regression when the fix is reverted.
+
+
+### Fixed
+
 - **`tstyles uninstall` silently corrupted a `$PROFILE` that contained a byte which is not valid UTF-8, and took no backup on the way out.** Step 3 of uninstall reads the whole of the user's `$PROFILE` and writes the whole of it back, exactly as the rc half does -- and it did so through UTF-8. `Get-RcFileEncoding` exists because of what that costs, and its own docstring spells it out: a latin-1 comment or a stray byte from an old editor decodes to U+FFFD and is written back as the replacement character, so "the user's own content, silently and permanently corrupted, by a tool that was only asked to append three lines". That was fixed for `.zshrc` and `.bashrc`; the `$PROFILE` half was a second, open-coded copy of the same removal and never got it. Measured on a profile whose first line was `# café`, byte `e9`:
 
   ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,15 @@ bound `-HomeDir` also suppresses the ambient `$env:ZDOTDIR`. `Invoke-TerminalSty
 takes `-Targets`. `Sync-ShellRuntime` has no seam and writes to the data root, so
 anything reaching it needs the data root sandboxed **as well as** `-HomeDir`.
 
+**Splatting an undefined variable fails UNSAFE here.** `Probe @neverDefined` does not pass
+"no arguments": it binds the FIRST POSITIONAL parameter to an empty string and makes
+`$PSBoundParameters.ContainsKey('HomeDir')` return `$true`. That is the exact guard used
+everywhere above to tell "the caller asked for a sandbox" from "use the live `$HOME`" — so
+losing a `$xSplat = @{}` line does not disable the seam, it announces a sandbox at the empty
+path. It has happened once already, to `$wezSplat`, dropped resolving a merge while both uses
+survived. `tests/Splat-Variables-Defined.Tests.ps1` walks the AST of every source file and
+fails if anything splats a variable its own scope never assigns; keep it passing.
+
 Never run `uninstall`, `delete`, `reset`, `register` or `shell-init` against the real
 environment to check something. Drive the underlying function in a sandbox instead,
 and mock `Confirm-Action` to refuse rather than relying on console detection.

--- a/lib/update.ps1
+++ b/lib/update.ps1
@@ -545,6 +545,14 @@ function Invoke-TerminalStylesUninstall {
     $profileSplat = @{}
     if ($PSBoundParameters.ContainsKey('ProfileTarget')) { $profileSplat.Target = $ProfileTarget }
 
+    # Get-WezTermModulePath takes no -ZDotDir, so it gets its own splat rather
+    # than $rcSplat. These two lines were on the branch that added the WezTerm
+    # writer and were lost resolving the merge with the $PROFILE-strip change
+    # above, which touched the same few lines -- while both USES of $wezSplat
+    # survived further down the function.
+    $wezSplat = @{}
+    if ($PSBoundParameters.ContainsKey('HomeDir')) { $wezSplat.HomeDir = $HomeDir }
+
     $dataDir = Get-TStylesDataRoot
     $kind = Get-TerminalStylesInstallKind
 

--- a/tests/Splat-Variables-Defined.Tests.ps1
+++ b/tests/Splat-Variables-Defined.Tests.ps1
@@ -1,0 +1,93 @@
+# Pester 5 tests: every splatted variable must be assigned in the function that
+# splats it.
+#
+# THE DEFECT THIS EXISTS FOR. `$wezSplat = @{}` and its ContainsKey line were
+# lost resolving a merge in Invoke-TerminalStylesUninstall, while both USES of
+# `@wezSplat` survived. PowerShell does not object to splatting a variable that
+# does not exist, and it does not pass "no arguments" either:
+#
+#     function Probe { param([string]$HomeDir) ... }
+#     Probe @neverDefined   ->   bound=True   value=[]
+#
+# It binds the FIRST POSITIONAL PARAMETER to an empty string, and
+# $PSBoundParameters.ContainsKey('HomeDir') reports TRUE. That is the exact
+# guard this codebase uses everywhere to tell "the caller asked for a sandbox"
+# from "use the live $HOME" -- so a lost splat variable does not disable the
+# seam, it reports a sandbox that was never requested, with an empty path. It
+# fails unsafe.
+#
+# Here it happened to throw on Join-Path, which is why five tests went red
+# rather than something silently resolving against the wrong home. That was
+# luck, not design.
+#
+# Run: Invoke-Pester -Path tests
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+BeforeDiscovery {
+    $script:repoRoot = Split-Path $PSScriptRoot -Parent
+    $script:sourceFiles = @(
+        (Join-Path $script:repoRoot 'tstyles.ps1')
+        (Join-Path $script:repoRoot 'terminals.ps1')
+        (Join-Path $script:repoRoot 'apply.ps1')
+        (Join-Path $script:repoRoot 'install.ps1')
+    ) + @(Get-ChildItem -Path (Join-Path $script:repoRoot 'lib') -Filter '*.ps1' |
+          ForEach-Object { $_.FullName })
+}
+
+Describe 'every splatted variable is assigned before it is splatted' {
+    It '<_> splats nothing it does not define' -ForEach $script:sourceFiles {
+        $path = $_
+        $errors = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile($path, [ref]$null, [ref]$errors)
+        @($errors).Count | Should -Be 0 -Because "$path must parse"
+
+        # Every function, plus the file's top level as one more scope.
+        $scopes = @($ast.FindAll({ param($n)
+            $n -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true))
+        $scopes += $ast
+
+        $bad = @()
+        foreach ($scope in $scopes) {
+            $name = if ($scope -is [System.Management.Automation.Language.FunctionDefinitionAst]) {
+                $scope.Name
+            } else { '<file scope>' }
+
+            # Splatted usages: a VariableExpressionAst with Splatted = $true.
+            $splatted = @($scope.FindAll({ param($n)
+                $n -is [System.Management.Automation.Language.VariableExpressionAst] -and $n.Splatted }, $true))
+            if (-not $splatted) { continue }
+
+            # Anything assigned anywhere in the same scope counts, however it
+            # was assigned -- '=', a foreach variable, or a param() default.
+            $assigned = [System.Collections.Generic.HashSet[string]]::new(
+                [System.StringComparer]::OrdinalIgnoreCase)
+            foreach ($a in $scope.FindAll({ param($n)
+                $n -is [System.Management.Automation.Language.AssignmentStatementAst] }, $true)) {
+                if ($a.Left -is [System.Management.Automation.Language.VariableExpressionAst]) {
+                    [void]$assigned.Add($a.Left.VariablePath.UserPath)
+                }
+            }
+            foreach ($p in $scope.FindAll({ param($n)
+                $n -is [System.Management.Automation.Language.ParameterAst] }, $true)) {
+                [void]$assigned.Add($p.Name.VariablePath.UserPath)
+            }
+            foreach ($f in $scope.FindAll({ param($n)
+                $n -is [System.Management.Automation.Language.ForEachStatementAst] }, $true)) {
+                [void]$assigned.Add($f.Variable.VariablePath.UserPath)
+            }
+
+            foreach ($s in $splatted) {
+                $v = $s.VariablePath.UserPath
+                if ($v -match '^(args|PSBoundParameters|null)$') { continue }
+                if ($assigned.Contains($v)) { continue }
+                $bad += "$name splats `@$v, which nothing in it assigns"
+            }
+        }
+
+        $bad -join "`n" | Should -BeNullOrEmpty -Because @'
+splatting an undefined variable binds the first positional parameter to an
+empty string AND reports it as bound, so a lost splat definition silently
+turns a "no sandbox requested" call into a "sandbox at the empty path" one
+'@
+    }
+}


### PR DESCRIPTION
**`main` is currently red.** The post-merge CI run for #23 failed; this fixes it.

## What happened

`$wezSplat = @{}` and the `ContainsKey('HomeDir')` line beside it were dropped resolving the merge between the WezTerm writer and #19's `$PROFILE`-strip change — both touched the same few lines at the top of `Invoke-TerminalStylesUninstall` — while **both uses of `@wezSplat` survived** further down. Five tests fail: uninstall throws before it can ask for consent.

Each PR was green on its own; the conflict resolution is what lost it.

## Why this did not fail loudly at the right place

This is the part worth reading. PowerShell does not object to splatting a variable that does not exist, and it does **not** pass "no arguments" either:

```
function Probe { param([string]$HomeDir) ... }

defined empty hashtable : bound=True value=[System.Collections.Hashtable]
UNDEFINED variable splat: bound=True value=[]
```

It binds the **first positional parameter to an empty string**, and `$PSBoundParameters.ContainsKey('HomeDir')` reports **$true**.

That `ContainsKey` test is the guard this codebase uses *everywhere* to tell "the caller asked for a sandbox" from "use the live `$HOME`" — the rule CLAUDE.md opens with. So a lost splat definition does not turn the seam off. **It announces a sandbox at the empty path.** It fails unsafe.

Here it threw on `Join-Path`, which is why five tests went red rather than something quietly resolving against the wrong home. That was luck, not design.

## The guard

`tests/Splat-Variables-Defined.Tests.ps1` walks the AST of every source file and fails if any scope splats a variable it never assigns — counting `=` assignments, `param()` names and `foreach` variables, per function and at file scope.

Reverting only `lib/update.ps1` makes it report exactly:

```
Invoke-TerminalStylesUninstall splats @wezSplat, which nothing in it assigns
```

CLAUDE.md gains the trap, next to the sandboxing rule it undermines.

Full suite: 1535 passed, 11 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4UptB5S567PxKmMdyH8T1