### PR TITLE
fix(picker): opening it on a theme-less style stripped settings.json and reported success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **opening the picker on a style that ships no `theme.json` stripped every comment out of `settings.json`, wrote none of the style, and reported success.** `Get-StyleSettingsPayload` decides what a style actually contributes to `settings.json`, and it had exactly three references repo-wide -- none of them in the picker, and none in `tests/`. So `tstyles aaa-schemeonly` correctly printed "ships no theme.json, so nothing was written to settings.json" and left the file byte-identical, while `tstyles` and Enter on the SAME style rewrote it: re-serialising the parsed object drops every JSONC comment the user had, nothing of the style was written, "Style applied" printed in green, and `tstyles current` then named a style Windows Terminal was never told about.
+
+  The load-bearing site is the FIRST PREVIEW, which fires the instant the picker opens, before a key is pressed. Measured end to end through the real picker on a real pty, with one Enter: `sha 978aca48 -> c1b9877e`, comment lines `4 -> 1`, `"schemes": []` still empty. With the fix the file comes back byte-identical at `978aca48`, all four comments intact, and the picker prints the direct path's own sentence.
+
+  The three merge sites are now one helper. Pasting the guard at each was the obvious fix and is how the rule came to be missing from all three; it would also have left the decision inside a function no test can drive, so the only possible regression test would have been a source-text assertion -- the shape this project has been bitten by twice.
+
+  Two things fell out of gating it that a naive guard would have broken. The picker relies on `settings.json` mirroring the highlighted row, so arrowing from a themed style onto a payload-less one now restores the user's original bytes rather than leaving the previous style's preview on disk under the new name. And Esc no longer writes at all when the picker never wrote: restoring over an untouched file is not free -- it drops a BOM the user had, bumps the mtime, and Windows Terminal watches the file and reloads.
+
 ## [0.8.24] - 2026-09-11
 
 ### Fixed

--- a/lib/picker.ps1
+++ b/lib/picker.ps1
@@ -127,6 +127,60 @@ function Get-PickerStyleSet {
 }
 
 
+function Get-StylePreviewJson {
+    # The settings.json the picker would write for one style -- or $null when
+    # that style has nothing to put there.
+    #
+    # Get-StyleSettingsPayload is the function that decides whether a style
+    # contributes anything to settings.json at all. Apply-StyleDirect asks it,
+    # apply.ps1 asks it, and 0.8.18's CHANGELOG says "all four write paths ...
+    # now check first" -- but the picker never did, because it held THREE
+    # open-coded copies of ConvertFrom-WTJson -> Merge-StyleIntoSettings ->
+    # ConvertTo-Json (the first preview, the per-keystroke apply, the idle
+    # prebuild) and none of them asked. A style with a scheme.json and no
+    # theme.json is legal -- README documents theme.json as optional and
+    # Get-AvailableStyles admits the folder, so it is listed and selectable --
+    # and Merge-StyleIntoSettings returns the settings object UNTOUCHED for it.
+    # The picker wrote that object anyway, which re-serializes what
+    # ConvertFrom-WTJson parsed and drops every // and /* */ comment the user
+    # wrote, then printed "Style applied: <name>" in green and recorded the
+    # style. So `tstyles current` and the `*` in `tstyles list` both named a
+    # style Windows Terminal had never been told about, while `tstyles <name>`
+    # on the very same style refused in as many words. The load-bearing copy was
+    # the FIRST preview, which fires as the picker opens -- before the user
+    # touches a key.
+    #
+    # One function, so there is one place that asks, and so a fourth copy cannot
+    # be added without it. $null means "nothing to write", which the picker's
+    # $writeSettings choke point already treats as a no-op -- the gate is the
+    # return value rather than a fourth guard beside a fourth merge.
+    #
+    # Carved out here for the same reason Invoke-StylePickerLoop and
+    # Get-PickerViewport are: the picker body cannot be driven by a test, and a
+    # decision that only exists inside it can only ever be asserted on its
+    # source text.
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$OriginalJson,
+        [Parameter(Mandatory)][string]$StyleDir,
+        [string]$TargetName,
+        [string]$BackgroundImage,
+        [bool]$BackgroundImageProvided
+    )
+
+    if (-not (Get-StyleSettingsPayload -StyleDir $StyleDir).Ok) { return $null }
+
+    $preview = ConvertFrom-WTJson $OriginalJson
+    $preview = Merge-StyleIntoSettings -Settings $preview -StyleDir $StyleDir `
+                   -TargetName $TargetName -BackgroundImage $BackgroundImage `
+                   -BackgroundImageProvided $BackgroundImageProvided
+    # Depth 100 (the JSON max), matching Write-SettingsFile: a user
+    # settings.json nested deeper than 32 is silently stringified by
+    # ConvertTo-Json, without warning on Windows PowerShell 5.1.
+    return $preview | ConvertTo-Json -Depth 100
+}
+
+
 function Test-ShouldRestoreWindowTitle {
     # Is there a window title worth putting back?
     #

--- a/tests/Picker-ConsoleGuards.Tests.ps1
+++ b/tests/Picker-ConsoleGuards.Tests.ps1
@@ -68,15 +68,20 @@ Describe 'the picker refuses a session with no real console' {
             # An ordering test that omits the call it should be ordering is
             # worth nothing.
             #
-            # Clear-Host is the scrollback wipe and Merge-StyleIntoSettings is
-            # the first thing that builds a settings.json to write.
+            # Clear-Host is the scrollback wipe and Get-StylePreviewJson is the
+            # first thing that builds a settings.json to write. It used to be
+            # Merge-StyleIntoSettings, named directly at three sites inside the
+            # picker; those three copies are now one call to the helper that
+            # asks Get-StyleSettingsPayload before it merges, so the merge
+            # itself no longer appears in this function at all and naming it
+            # here would assert over zero call sites.
             #
             # NOT Write-SettingsAtomic, though it is the actual write: its one
             # call site lives inside the $writeSettings scriptblock, which is
             # DEFINED above the guard and invoked below it. Comparing source
             # offsets would flag that as a violation and be wrong -- the check
             # measures where code is written, not when it runs.
-            foreach ($name in 'Read-Host', 'Clear-Host', 'Merge-StyleIntoSettings') {
+            foreach ($name in 'Read-Host', 'Clear-Host', 'Get-StylePreviewJson') {
                 $calls = @($ast.FindAll({ param($n)
                     $n -is [System.Management.Automation.Language.CommandAst] -and
                     $n.GetCommandName() -eq $name }, $true))

--- a/tests/Picker-SettingsPayload.Tests.ps1
+++ b/tests/Picker-SettingsPayload.Tests.ps1
@@ -1,0 +1,349 @@
+# Pester 5 tests: the picker may not write settings.json for a style that has
+# nothing to put there.
+#
+# THE RULE, already established twice. Merge-StyleIntoSettings returns the
+# settings object UNTOUCHED for a style with a scheme.json and no theme.json --
+# deliberately, because a colour scheme is only reachable through a profile's
+# colorScheme key, which theme.json carries. Writing the returned object anyway
+# is NOT a no-op: it re-serializes what ConvertFrom-WTJson parsed, which drops
+# every // and /* */ comment and every trailing comma the user wrote. So the
+# caller has to ask Get-StyleSettingsPayload FIRST. Apply-StyleDirect asks;
+# apply.ps1 asks; 0.8.18's CHANGELOG says "all four write paths -- the direct
+# apply, the picker, the tuner and apply.ps1 -- now check first and say plainly
+# that nothing was written."
+#
+# The picker never did. It held three open-coded copies of ConvertFrom-WTJson ->
+# Merge-StyleIntoSettings -> ConvertTo-Json -> write, and Get-StyleSettingsPayload
+# had exactly three references in the whole repo, none of them in tstyles.ps1 and
+# none in tests/. A style directory with scheme.json and no theme.json is legal
+# (README documents theme.json as optional) and Get-AvailableStyles admits it on
+# scheme.json existing, so it is listed and selectable. `tstyles aaa-schemeonly`
+# refused it in as many words and left settings.json byte-identical; `tstyles`
+# and Enter on the SAME style stripped every comment out of settings.json, wrote
+# nothing of the style, printed "Style applied: aaa-schemeonly" in green with no
+# qualifier, and recorded it -- so `tstyles current` and the `*` in `tstyles
+# list` both named a style Windows Terminal had never been told about. The
+# load-bearing copy was the FIRST preview, which fires as the picker opens,
+# before a key is pressed.
+#
+# WHY THESE TESTS HAVE THIS SHAPE. The picker body cannot be driven by a test:
+# it returns early on [Console]::IsInputRedirected / IsOutputRedirected, which
+# are .NET statics and true under Pester. So the decision was carved out into
+# Get-StylePreviewJson in lib/picker.ps1 -- the same reason Invoke-StylePickerLoop
+# and Get-PickerViewport live there -- and the behavioural half below drives that
+# for real. The structural half then pins the rule for every OTHER caller,
+# because what actually went wrong here is that a function was added in 0.8.18
+# with three of its four intended callers wired up and nothing anywhere held the
+# fourth.
+#
+# Run: Invoke-Pester -Path tests
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+BeforeDiscovery {
+    $repoRoot = Split-Path $PSScriptRoot -Parent
+    Import-Module (Join-Path $repoRoot 'TerminalStyles.psd1') -Force -DisableNameChecking *> $null
+}
+BeforeAll {
+    $repoRoot = Split-Path $PSScriptRoot -Parent
+    Import-Module (Join-Path $repoRoot 'TerminalStyles.psd1') -Force -DisableNameChecking *> $null
+}
+
+Describe 'Get-StylePreviewJson decides whether the picker writes at all' {
+    InModuleScope TerminalStyles {
+        BeforeEach {
+            $script:TStylesModuleRoot = $TestDrive
+            $script:TStylesDataRoot   = $TestDrive
+
+            # A settings.json in the shape the picker actually reads: the byte-
+            # exact source text, carrying the comments that are the thing at
+            # risk. JSONC -- which is what Windows Terminal ships and what
+            # ConvertFrom-WTJson exists to parse.
+            $script:live = @'
+{
+    // My Windows Terminal settings -- hand-tuned, do not lose me!
+    "profiles": { "list": [ { "name": "PowerShell", "guid": "{x}" } ] },
+    "schemes": []
+}
+'@
+
+            # scheme.json and NO theme.json. Legal per README, and nothing for
+            # Windows Terminal.
+            $script:schemeOnly = Join-Path $TestDrive 'styles/aaa-schemeonly'
+            New-Item -ItemType Directory -Path $script:schemeOnly -Force | Out-Null
+            [System.IO.File]::WriteAllText((Join-Path $script:schemeOnly 'scheme.json'),
+                '{"name":"aaa-schemeonly","background":"#101010","foreground":"#e0e0e0"}',
+                [System.Text.UTF8Encoding]::new($false))
+
+            # The control: the same fixture WITH a theme.json. Without this the
+            # test below would pass just as well against a helper that returned
+            # $null for everything, which is a fix that breaks the picker
+            # outright.
+            $script:full = Join-Path $TestDrive 'styles/zzz-full'
+            New-Item -ItemType Directory -Path $script:full -Force | Out-Null
+            [System.IO.File]::WriteAllText((Join-Path $script:full 'scheme.json'),
+                '{"name":"zzz-full","background":"#202020","foreground":"#f0f0f0"}',
+                [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText((Join-Path $script:full 'theme.json'),
+                '{"colorScheme":"zzz-full","cursorShape":"bar"}',
+                [System.Text.UTF8Encoding]::new($false))
+
+            # Merge-StyleIntoSettings resolves a bundled background when the
+            # caller did not provide one, and its third tier lazily FETCHES from
+            # the gifs branch into the cache. Neither fixture ships an image, so
+            # $null is the true answer -- mocked so the suite never reaches the
+            # network to find that out. (0.8.24: an ordinary suite run used to
+            # download a real 3 MB eva.gif this way.)
+            Mock Get-StyleBundledBackground { $null }
+        }
+
+        It 'returns $null for a style with scheme.json and no theme.json' {
+            # $null is how the picker's $writeSettings choke point is told there
+            # is nothing to write. Before the fix this returned a full JSON
+            # document -- the user's settings re-serialized, comments gone, and
+            # not one field of the style in it.
+            $json = Get-StylePreviewJson -OriginalJson $script:live -StyleDir $script:schemeOnly `
+                        -TargetName 'PowerShell' -BackgroundImage '' -BackgroundImageProvided $false
+            $json | Should -BeNullOrEmpty `
+                -Because 'the merge has nothing to merge, so there must be no JSON to write'
+        }
+
+        It 'agrees with Get-StyleSettingsPayload rather than deciding for itself' {
+            # One rule, one place that knows it. If these two ever disagree the
+            # picker and `tstyles <name>` are back to answering differently for
+            # the same style, which is the whole defect.
+            $payload = Get-StyleSettingsPayload -StyleDir $script:schemeOnly
+            $payload.Ok      | Should -BeFalse
+            $payload.Missing | Should -Be 'theme.json'
+        }
+
+        It 'still builds the full preview for a style that has a theme.json' {
+            $json = Get-StylePreviewJson -OriginalJson $script:live -StyleDir $script:full `
+                        -TargetName 'PowerShell' -BackgroundImage '' -BackgroundImageProvided $false
+            $json | Should -Not -BeNullOrEmpty
+
+            # Parsed, not string-matched: what matters is that the scheme landed
+            # in schemes AND that the profile now points at it, which is the
+            # pair that makes a style actually visible.
+            $out = $json | ConvertFrom-Json
+            @($out.schemes | ForEach-Object { $_.name }) | Should -Contain 'zzz-full'
+            $profile = @($out.profiles.list | Where-Object { $_.name -eq 'PowerShell' })[0]
+            $profile.colorScheme | Should -Be 'zzz-full'
+            $profile.cursorShape | Should -Be 'bar'
+        }
+
+        It 'writes nothing for the scheme-only style even under the picker choke point' {
+            # The consequence, end to end through the one writer the picker uses.
+            # $writeSettings is a scriptblock inside Invoke-TerminalStyle and
+            # cannot be reached from here, but its rule is "an empty $Json is a
+            # no-op", so this is that rule applied to this helper's answer.
+            $path = Join-Path $TestDrive 'settings.json'
+            [System.IO.File]::WriteAllText($path, $script:live, [System.Text.UTF8Encoding]::new($false))
+            $before = [System.IO.File]::ReadAllBytes($path)
+
+            $json = Get-StylePreviewJson -OriginalJson $script:live -StyleDir $script:schemeOnly `
+                        -TargetName 'PowerShell' -BackgroundImage '' -BackgroundImageProvided $false
+            if ($json) { Write-SettingsAtomic -Path $path -Json $json }
+
+            [System.IO.File]::ReadAllBytes($path) | Should -Be $before `
+                -Because 'a preview with nothing in it must leave the file byte-identical'
+            [System.IO.File]::ReadAllText($path) | Should -Match 'hand-tuned, do not lose me'
+        }
+
+        It 'and the rewrite it avoids really would have eaten the comments' {
+            # The premise, measured rather than asserted from the CHANGELOG: a
+            # settings.json that goes through ConvertFrom-WTJson and back out
+            # comes back without a single comment. This is why "write the
+            # untouched object anyway" is not a harmless no-op, and why the gate
+            # has to be in front of the merge rather than after it.
+            $script:live | Should -Match 'hand-tuned, do not lose me'
+            $roundTripped = ConvertFrom-WTJson $script:live | ConvertTo-Json -Depth 100
+            $roundTripped | Should -Not -Match 'hand-tuned, do not lose me'
+            $roundTripped | Should -Match '"schemes"' -Because 'it is otherwise the same document'
+        }
+    }
+}
+
+Describe 'every settings.json writer asks first' {
+    # The structural half. Get-StyleSettingsPayload was added in 0.8.18 with
+    # three of its four intended callers wired up, and nothing anywhere pinned
+    # the fourth -- so the picker kept eating comments for six releases while a
+    # release note said it did not. This is that release note, as code.
+
+    BeforeAll {
+        $script:repoRoot = Split-Path $PSScriptRoot -Parent
+
+        # Every file that could hold a writer, not just the ones that do today.
+        $script:sourceFiles = @(
+            (Join-Path $script:repoRoot 'tstyles.ps1')
+            (Join-Path $script:repoRoot 'terminals.ps1')
+            (Join-Path $script:repoRoot 'apply.ps1')
+            (Join-Path $script:repoRoot 'install.ps1')
+        ) + @(Get-ChildItem -LiteralPath (Join-Path $script:repoRoot 'lib') -Filter '*.ps1' |
+                ForEach-Object { $_.FullName })
+
+        $script:roots = @{}
+        foreach ($p in $script:sourceFiles) {
+            $script:roots[$p] = [System.Management.Automation.Language.Parser]::ParseFile($p, [ref]$null, [ref]$null)
+        }
+
+        # The scope a call has to be judged in: the innermost function that
+        # contains it, or the whole file when the call is at script level
+        # (apply.ps1 is a standalone script and has no enclosing function).
+        function script:Get-EnclosingScope {
+            param($Root, $Node)
+            $best = $null
+            foreach ($f in $Root.FindAll({ param($n)
+                        $n -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true)) {
+                if ($Node.Extent.StartOffset -ge $f.Extent.StartOffset -and
+                    $Node.Extent.EndOffset   -le $f.Extent.EndOffset) {
+                    if ($null -eq $best -or $f.Extent.StartOffset -gt $best.Extent.StartOffset) { $best = $f }
+                }
+            }
+            if ($best) { return $best }
+            return $Root
+        }
+
+        function script:Get-ArgumentText {
+            param($CommandAst, [string]$ParameterName)
+            $els = @($CommandAst.CommandElements)
+            for ($i = 0; $i -lt $els.Count; $i++) {
+                $e = $els[$i]
+                if ($e -is [System.Management.Automation.Language.CommandParameterAst] -and
+                    $e.ParameterName -eq $ParameterName) {
+                    if ($e.Argument) { return $e.Argument.Extent.Text }
+                    if ($i + 1 -lt $els.Count) { return $els[$i + 1].Extent.Text }
+                }
+            }
+            return $null
+        }
+    }
+
+    It 'is looking at the files it thinks it is' {
+        # A parse that silently returned nothing would make every assertion
+        # below pass over zero call sites, which is the exact way the swatch
+        # guard reported green for its whole life.
+        $script:sourceFiles.Count | Should -BeGreaterOrEqual 10
+        foreach ($expected in 'tstyles.ps1', 'apply.ps1', 'picker.ps1', 'applystyle.ps1', 'tune.ps1', 'wtsettings.ps1') {
+            @($script:sourceFiles | Where-Object { (Split-Path $_ -Leaf) -eq $expected }).Count |
+                Should -Be 1 -Because "$expected must be in the scanned set"
+        }
+        foreach ($p in $script:sourceFiles) {
+            $script:roots[$p] | Should -Not -BeNullOrEmpty -Because "$p must parse"
+        }
+    }
+
+    It 'no scope merges a style into settings.json without asking whether it has anything to write' {
+        $total = 0
+        $viaPayload = 0
+        $viaOwnTheme = 0
+        $offenders = @()
+
+        foreach ($p in $script:sourceFiles) {
+            $root = $script:roots[$p]
+            $merges = @($root.FindAll({ param($n)
+                $n -is [System.Management.Automation.Language.CommandAst] -and
+                $n.GetCommandName() -eq 'Merge-StyleIntoSettings' }, $true))
+
+            foreach ($m in $merges) {
+                $total++
+                $scope = script:Get-EnclosingScope -Root $root -Node $m
+
+                $asks = @($scope.FindAll({ param($n)
+                    $n -is [System.Management.Automation.Language.CommandAst] -and
+                    $n.GetCommandName() -eq 'Get-StyleSettingsPayload' }, $true)).Count -gt 0
+                if ($asks) { $viaPayload++; continue }
+
+                # The one legitimate other way to satisfy the rule: be the thing
+                # that WROTE the theme.json you are about to merge. The tuner's
+                # preview builds a scratch style dir three statements above its
+                # merge, so the answer is known without asking. Pinned on that
+                # same directory, not excused by name -- a tuner that stopped
+                # writing the file would fail here.
+                #
+                # The WriteAllText wrapper is load-bearing, and was found the
+                # hard way: `Join-Path <dir> 'theme.json'` alone also matches
+                # somebody READING the file, and the picker reads exactly that
+                # path a hundred lines above its merge to pre-load tab titles.
+                # A rule that exempts a reader excuses the very call site it
+                # exists to catch -- and did, silently, until the reverted-fix
+                # run named two offenders where there were three.
+                $dir = script:Get-ArgumentText -CommandAst $m -ParameterName 'StyleDir'
+                if ($dir -and $scope.Extent.Text -match
+                        ("WriteAllText\(\s*\(\s*Join-Path\s+{0}\s+'theme\.json'\s*\)" -f [regex]::Escape($dir))) {
+                    $viaOwnTheme++
+                    continue
+                }
+
+                $offenders += ('{0}:{1} in {2}' -f (Split-Path $p -Leaf),
+                               $m.Extent.StartLineNumber,
+                               $(if ($scope -is [System.Management.Automation.Language.FunctionDefinitionAst]) { $scope.Name } else { '<script>' }))
+            }
+        }
+
+        # The offenders first, because the list names the file, line and
+        # function and is what a reader needs. The counts follow and are not
+        # decoration: an AST walk that found nothing would report an empty
+        # offender list and a green tick, which is exactly how the swatch guard
+        # compared zero pairs of themes for its whole life. Four callers today
+        # -- Get-StylePreviewJson, Apply-StyleDirect, apply.ps1 and the tuner's
+        # preview.
+        $offenders -join '; ' | Should -BeNullOrEmpty `
+            -Because 'a merge that is written out without asking is a settings.json rewrite that can do nothing but delete comments'
+        $total | Should -BeGreaterOrEqual 4 -Because 'the walk must actually find the merge call sites'
+        $viaPayload  | Should -BeGreaterOrEqual 3 -Because 'the payload check is how most callers satisfy this'
+        $viaOwnTheme | Should -BeGreaterOrEqual 1 -Because 'the tuner satisfies it the other way, so that branch is live'
+        ($viaPayload + $viaOwnTheme) | Should -Be $total
+    }
+
+    It 'the picker goes through the one helper rather than merging inline again' {
+        # Three inline copies is how the check came to be missing from all three.
+        $fn = (Get-Command Invoke-TerminalStyle).ScriptBlock.Ast
+        $called = @($fn.FindAll({ param($n)
+            $n -is [System.Management.Automation.Language.CommandAst] }, $true) |
+            ForEach-Object { $_.GetCommandName() } | Where-Object { $_ })
+
+        $called | Should -Contain 'Get-StylePreviewJson'
+        $called | Should -Not -Contain 'Merge-StyleIntoSettings' `
+            -Because 'a fourth inline merge in the picker is how this defect comes back'
+    }
+}
+
+Describe 'the picker says the same thing the direct path says' {
+    # "Every user-facing message is a claim." The picker printed "Style applied:
+    # <name>" in green with no qualifier for a style Windows Terminal was never
+    # told about, while `tstyles <name>` on the same style said so outright.
+    # Pinned on the shared tail of the sentence so the two doors cannot drift
+    # into wording that means different things.
+    #
+    # InModuleScope because Apply-StyleDirect is internal: outside it,
+    # Get-Command returns nothing and `$null | Should -Match` is a failure
+    # rather than a pass, but a less strict assertion here would have compared
+    # nothing at all.
+    InModuleScope TerminalStyles {
+
+        It 'both paths carry the same "nothing was written" sentence' {
+            $picker = (Get-Command Invoke-TerminalStyle).ScriptBlock.Ast.Extent.Text
+            $direct = (Get-Command Apply-StyleDirect).ScriptBlock.Ast.Extent.Text
+            $picker | Should -Not -BeNullOrEmpty
+            $direct | Should -Not -BeNullOrEmpty
+
+            $direct | Should -Match 'ships no .*so nothing was written to settings\.json' `
+                -Because 'this is the sentence the direct path has printed since 0.8.18'
+            $picker | Should -Match 'ships no .*so nothing was written to settings\.json' `
+                -Because 'the picker must qualify its green success line the same way'
+        }
+
+        It 'and the picker still records the style, because off settings.json it really is applied' {
+            # Deliberately NOT gated with the write. The prompt, the palette and
+            # the shell state are the style's other halves and they were
+            # applied; the record is what makes `tstyles current` and the `*` in
+            # `tstyles list` work at all, and for a style that ships no
+            # profile.ps1 it is the only thing that remembers.
+            $picker = (Get-Command Invoke-TerminalStyle).ScriptBlock.Ast
+            $called = @($picker.FindAll({ param($n)
+                $n -is [System.Management.Automation.Language.CommandAst] }, $true) |
+                ForEach-Object { $_.GetCommandName() } | Where-Object { $_ })
+            $called | Should -Contain 'Set-CurrentStyleRecord'
+        }
+    }
+}

--- a/tests/Picker-ShellStateStaging.Tests.ps1
+++ b/tests/Picker-ShellStateStaging.Tests.ps1
@@ -286,8 +286,21 @@ Describe 'the picker puts the terminal back when you cancel' {
     It 'tracks the revert in a reference type, not a plain bool' {
         # A scriptblock assigning to a [bool] would land in its own child scope
         # and the finally would never see it, so the revert would run twice.
+        #
+        # The bag now carries SettingsWritten as well, for the same reason and
+        # with the same consequence if it were a plain [bool]: the write and the
+        # restore both live in scriptblocks, and the restore has to know whether
+        # the picker put a preview on disk at all. A style with no theme.json
+        # writes nothing, and restoring "the original" over a file we never
+        # touched drops its BOM and makes Windows Terminal reload for nothing.
+        # Matched field by field rather than as one exact literal, so adding a
+        # third piece of picker state does not turn this into a red test about
+        # nothing.
         $fn = script:Get-FunctionAst -Name 'Invoke-TerminalStyle'
-        $fn.Extent.Text | Should -Match '\$pickerState\s*=\s*@\{\s*Reverted\s*=\s*\$false\s*\}'
+        $src = $fn.Extent.Text
+        $src | Should -Match '\$pickerState\s*=\s*@\{[^}]*\bReverted\s*=\s*\$false'
+        $src | Should -Match '\$pickerState\s*=\s*@\{[^}]*\bSettingsWritten\s*=\s*\$false'
+        $src | Should -Match '\$pickerState\.SettingsWritten\s*=\s*\$true'
     }
 }
 
@@ -316,9 +329,14 @@ Describe 'the picker does not burn work it throws away' {
     It 'still prebuilds on Windows Terminal, where the scan is used' {
         # The fix must not have cost WT its prebuild -- that cache is what makes
         # arrow-keying back to a visited style instant.
+        #
+        # Get-StylePreviewJson, not Merge-StyleIntoSettings: the picker's three
+        # open-coded merges are now one helper, which is what made it possible
+        # to ask Get-StyleSettingsPayload in one place instead of forgetting it
+        # in three.
         $fn = script:Get-FunctionAst -Name 'Invoke-TerminalStyle'
         $idle = [regex]::Match($fn.Extent.Text, '(?s)\$onIdle = \{.*?\n        \}').Value
-        $idle | Should -Match 'Merge-StyleIntoSettings'
+        $idle | Should -Match 'Get-StylePreviewJson'
         $idle | Should -Match 'mergedCache\['
     }
 }

--- a/tstyles.ps1
+++ b/tstyles.ps1
@@ -766,13 +766,42 @@ function Invoke-TerminalStyle {
         if ($Target -and -not (& $validateTarget $Target)) { return }
     }
 
+    # A hashtable, not plain variables: the revert and the writes below run
+    # inside scriptblocks, and a plain assignment there would land in the
+    # scriptblock's own child scope and never be seen out here. The finally
+    # block needs to know whether the revert already happened, and the revert
+    # needs to know whether there is anything to revert.
+    $pickerState = @{ Reverted = $false; SettingsWritten = $false }
+
     # Single choke point for every settings.json write in the picker. Off
     # Windows Terminal this is a no-op, so the loop below reads the same in
-    # both worlds instead of repeating the guard at each call site.
+    # both worlds instead of repeating the guard at each call site. An empty or
+    # $null $Json is a no-op too -- that is how Get-StylePreviewJson says "this
+    # style has nothing for settings.json" without every caller re-testing it.
     $writeSettings = {
         param([string]$Json)
         if ($useSettingsFile -and $Json) {
             Write-SettingsAtomic -Path $settingsPath -Json $Json
+            $pickerState.SettingsWritten = $true
+        }
+    }
+
+    # The other half of that choke point: put the user's own settings.json back.
+    # $originalJson is the byte-exact source text, so this restores the // and
+    # /* */ comments ConvertFrom-WTJson dropped on the way into a preview.
+    #
+    # Guarded on having written, because a picker session can now legitimately
+    # write NOTHING -- open it on a style with no theme.json and press Esc and
+    # there is no preview on disk to undo. Restoring anyway would rewrite the
+    # file with the same characters, which is not free: Write-SettingsAtomic
+    # emits UTF-8 with no BOM (so a BOM the user had is gone), it bumps the
+    # mtime, and Windows Terminal watches the file and reloads on the change.
+    # "Nothing was written to settings.json" has to mean the file was not
+    # touched, or it is the same claim this whole path was fixed for.
+    $restoreOriginalSettings = {
+        if ($pickerState.SettingsWritten) {
+            & $writeSettings $originalJson
+            $pickerState.SettingsWritten = $false
         }
     }
 
@@ -878,11 +907,6 @@ function Invoke-TerminalStyle {
     # because $idx is the live cursor and has moved by the time Esc arrives.
     $startIdx        = $idx
     $hadCurrentStyle = ($currentIdx -ge 0)
-    # A hashtable, not a [bool]: the revert runs inside a scriptblock, and a
-    # plain assignment there would land in the scriptblock's own child scope and
-    # never be seen out here. The finally block needs to know whether the revert
-    # already happened.
-    $pickerState     = @{ Reverted = $false }
 
     # Each style's color swatch AND its parsed scheme object, both from the
     # single guarded read above -- keyed by index into the filtered $styles, so
@@ -1089,11 +1113,21 @@ function Invoke-TerminalStyle {
         # entirely off Windows Terminal: there is no $originalJson to merge into,
         # and the OSC packet emitted by the render loop is the whole preview.
         if ($useSettingsFile) {
-            $preview = ConvertFrom-WTJson $originalJson
-            $preview = Merge-StyleIntoSettings -Settings $preview -StyleDir $styles[$idx].FullName -TargetName $Target -BackgroundImage $BackgroundImage -BackgroundImageProvided $bgProvided
-            $initialJson = $preview | ConvertTo-Json -Depth 100
+            # Through Get-StylePreviewJson, which asks Get-StyleSettingsPayload
+            # first and answers $null for a style that has nothing to write --
+            # a $null the $writeSettings choke point above already no-ops on.
+            # This is the site that cost the comments: it fires as the picker
+            # opens, before a key is pressed, so bare `tstyles` on a style with
+            # no theme.json rewrote settings.json from the parsed object (every
+            # // and /* */ comment gone), wrote nothing of the style, and then
+            # reported success.
+            $initialJson = Get-StylePreviewJson -OriginalJson $originalJson -StyleDir $styles[$idx].FullName `
+                               -TargetName $Target -BackgroundImage $BackgroundImage -BackgroundImageProvided $bgProvided
             & $writeSettings $initialJson
-            if (Test-StyleResolved -StyleDir $styles[$idx].FullName) {
+            # Never cache a $null: $mergedCache is consulted with ContainsKey,
+            # so an entry for a style with no payload would read as "already
+            # built" and skip the restore below for the rest of the session.
+            if ($initialJson -and (Test-StyleResolved -StyleDir $styles[$idx].FullName)) {
                 $mergedCache[$idx] = $initialJson
             }
         } else {
@@ -1248,11 +1282,20 @@ function Invoke-TerminalStyle {
             if ($resolved -and $mergedCache.ContainsKey($i)) {
                 & $writeSettings $mergedCache[$i]
             } else {
-                $preview = ConvertFrom-WTJson $originalJson
-                $preview = Merge-StyleIntoSettings -Settings $preview -StyleDir $styles[$i].FullName -TargetName $Target -BackgroundImage $BackgroundImage -BackgroundImageProvided $bgProvided
-                $json = $preview | ConvertTo-Json -Depth 100
-                & $writeSettings $json
-                if ($resolved) { $mergedCache[$i] = $json }
+                $json = Get-StylePreviewJson -OriginalJson $originalJson -StyleDir $styles[$i].FullName `
+                            -TargetName $Target -BackgroundImage $BackgroundImage -BackgroundImageProvided $bgProvided
+                if ($json) {
+                    & $writeSettings $json
+                    if ($resolved) { $mergedCache[$i] = $json }
+                } else {
+                    # Nothing to preview -- but an EARLIER style's preview may
+                    # still be on disk, and leaving it there would show, and
+                    # then on Enter confirm, another style's colours under this
+                    # one's name. The style's contribution to settings.json is
+                    # the user's own file, so put that back. (A no-op when the
+                    # picker has not written; see $restoreOriginalSettings.)
+                    & $restoreOriginalSettings
+                }
             }
             if ($titles.ContainsKey($i)) { $Host.UI.RawUI.WindowTitle = $titles[$i] }
         }
@@ -1271,7 +1314,7 @@ function Invoke-TerminalStyle {
         # sequences, so resetting drops them to the terminal's stock palette
         # rather than back to their style. Re-emit it instead.
         $restoreOriginalLook = {
-            & $writeSettings $originalJson
+            & $restoreOriginalSettings
             if (-not $useSettingsFile -and $hadCurrentStyle -and $schemes.ContainsKey($startIdx)) {
                 Write-HostOscPacket -Packet (Get-SchemeOscPacket -Scheme $schemes[$startIdx]) | Out-Null
             } else {
@@ -1296,14 +1339,21 @@ function Invoke-TerminalStyle {
             $nextPrebuild = -1
             for ($j = 0; $j -lt $styles.Count; $j++) {
                 if ($mergedCache.ContainsKey($j)) { continue }
+                # Skipped BEFORE the Test-StyleResolved probe, and on the same
+                # question Get-StylePreviewJson answers below: a style with
+                # nothing for settings.json has no JSON to prebuild, and the
+                # scan restarts from 0 every tick -- so without this it would
+                # be chosen as $nextPrebuild ~20 times a second for the life of
+                # the picker and no style after it would ever be cached.
+                if (-not (Get-StyleSettingsPayload -StyleDir $styles[$j].FullName).Ok) { continue }
                 if (-not (Test-StyleResolved -StyleDir $styles[$j].FullName)) { continue }
                 $nextPrebuild = $j
                 break
             }
             if ($nextPrebuild -ge 0) {
-                $pp = ConvertFrom-WTJson $originalJson
-                $pp = Merge-StyleIntoSettings -Settings $pp -StyleDir $styles[$nextPrebuild].FullName -TargetName $Target -BackgroundImage $BackgroundImage -BackgroundImageProvided $bgProvided
-                $mergedCache[$nextPrebuild] = $pp | ConvertTo-Json -Depth 100
+                $ppJson = Get-StylePreviewJson -OriginalJson $originalJson -StyleDir $styles[$nextPrebuild].FullName `
+                              -TargetName $Target -BackgroundImage $BackgroundImage -BackgroundImageProvided $bgProvided
+                if ($ppJson) { $mergedCache[$nextPrebuild] = $ppJson }
             } else {
                 Start-Sleep -Milliseconds 50
             }
@@ -1442,6 +1492,26 @@ function Invoke-TerminalStyle {
         Write-Host "  Style applied: " -NoNewline
         Write-Host $selectedStyle.Name -ForegroundColor Green
         Write-Host ""
+
+        # The same qualifier `tstyles <name>` prints, from the same function, so
+        # the two doors give the same answer. Without it the picker claimed a
+        # bare success for a style Windows Terminal was never told about. The
+        # Set-CurrentStyleRecord above is still right -- off settings.json the
+        # style really is applied, as the prompt and the palette, and the record
+        # is what makes `tstyles current` work at all -- but "Style applied" on
+        # its own reads as "settings.json now has it", and it does not.
+        #
+        # Re-asked here rather than remembered from the preview: the answer is
+        # about the style the user actually confirmed, and it names the file
+        # that is missing rather than assuming which one it was.
+        if ($useSettingsFile) {
+            $confirmPayload = Get-StyleSettingsPayload -StyleDir $selectedStyle.FullName
+            if (-not $confirmPayload.Ok) {
+                Write-Host ("  '{0}' ships no {1}, so nothing was written to settings.json." -f
+                            $selectedStyle.Name, $confirmPayload.Missing) -ForegroundColor DarkGray
+                Write-Host ""
+            }
+        }
         if ($pendingUpdate) {
             Write-Host ("  Update available ({0} -> {1}). Run: tstyles update" -f
                         $pendingUpdate.Installed, $pendingUpdate.Remote) -ForegroundColor Yellow


### PR DESCRIPTION
From the audit ledger (finding 19).

## The defect

`Get-StyleSettingsPayload` decides what a style actually contributes to `settings.json`. It had **three references repo-wide — none in the picker, and none in `tests/`**.

So for a style shipping a scheme but no `theme.json`:

- `tstyles aaa-schemeonly` prints *"ships no theme.json, so nothing was written to settings.json"* and leaves the file byte-identical
- `tstyles` + Enter on the **same style** rewrites it — re-serialising the parsed object drops every JSONC comment — writes nothing of the style, prints "Style applied" in green, and records it, so `tstyles current` names a style Windows Terminal was never told about

The load-bearing site is the **first preview**, which fires the instant the picker opens, before a key is pressed.

## Measured through the real picker, real pty, one Enter

```
UNFIXED:  sha 978aca48 -> c1b9877e
          comment lines 4 -> 1     (the survivor is "//" inside a URL)
          "schemes": [] still empty, no colorScheme on the profile
          output ends: "  Style applied: aaa-schemeonly"

FIXED:    sha 978aca48 -> 978aca48
          comment lines 4 -> 4
          output ends: "  Style applied: aaa-schemeonly"
                       "  'aaa-schemeonly' ships no theme.json, so nothing was written to settings.json."
```

## Why one helper instead of three guards

The obvious fix is pasting `if (…).Ok` at each of the three merge sites. **That is how the rule came to be missing from all three**, and it leaves the decision inside a function no test can drive — so the only possible regression test would be a source-text assertion, the shape this project has been bitten by twice. The three sites are now one `Get-StylePreviewJson` in `lib/picker.ps1`.

Verified: `Merge-StyleIntoSettings` now appears **zero** times inside `Invoke-TerminalStyle` (AST-checked; the two textual hits are comments).

## Two things a naive gate would have broken

**The picker relies on `settings.json` mirroring the highlighted row.** Arrow onto `eva` (writes eva), arrow back onto the theme-less style (now writes nothing), press Enter — the confirm would say `aaa-schemeonly` + "nothing was written" while the file holds eva. A new lie for an old one. Arrowing onto a payload-less style now restores the user's original bytes.

**Esc no longer writes when the picker never wrote.** Restoring over an untouched file is not free: it drops a BOM the user had, bumps the mtime, and Windows Terminal watches the file and reloads. Same guard covers the Ctrl+C / finally revert.

`Save-SettingsBackup` and `Set-CurrentStyleRecord` are deliberately unchanged — the backup is crash recovery taken before the picker knows which styles you will visit, and off `settings.json` the style genuinely *is* applied.

## The test caught its own defect first

Worth recording. The AST rule's first exemption regex was `Join-Path <dir> 'theme.json'` — and the reverted run named only **two** of three offenders. The third was exempted because the picker *reads* `Join-Path … 'theme.json'` a hundred lines earlier for tab titles. The rule now requires `WriteAllText((Join-Path …))`, and names all three. Without that it would have excused the very site class it exists to catch.

## Verification

Binding: 6 of 10 new tests fail against the reverted source; 3 more in two updated files. I independently drove `Get-StylePreviewJson` — `NULL` for scheme-only, a built preview for themed — and AST-verified the inline merges are gone.

Full suite: 1664 passed, 11 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4UptB5S567PxKmMdyH8T1
