### PR TITLE
fix(install): the execution-policy fix verified the wrong scope and reported success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **the installer's execution-policy fix verified the wrong scope, so it reported success on exactly the machines where it had failed.** `install.ps1` asks "can the loader run?" twice and asked two different questions. The PRE-check reads `Get-ExecutionPolicy` with no scope -- the EFFECTIVE policy, which is what actually decides whether a script runs. The POST-check read `Get-ExecutionPolicy -Scope CurrentUser`: the value it had just written. Precedence is MachinePolicy > UserPolicy > Process > CurrentUser > LocalMachine, so the scoped read-back cannot detect the failure the pre-check was asking about. On a machine with a Group Policy pinning the policy, `Set-ExecutionPolicy -Scope CurrentUser` SUCCEEDS -- it writes HKCU and only warns that the setting is overridden -- the scope reads back `RemoteSigned`, and the installer printed a green "Done." while the loader still could not run. The write keeps its scope, because CurrentUser is the one that needs no elevation; only the verification changed.
+
+- `Test-PolicyResolved` accepted `Undefined` as "scripts are allowed". `Undefined` is what a single SCOPE reads back when nothing was ever written there -- it means "no answer", not "allowed" -- and an effective `Get-ExecutionPolicy` never returns it, since an all-Undefined machine resolves to the platform default, `Restricted` on Windows clients. So rejecting it costs nothing and stops a scoped value that reaches the function by mistake from reading as resolved, which is precisely what the post-check above was doing: a write that never landed announced in green as "policy is now Undefined".
+
+- the advice printed when the policy fix fails named the wrong culprit. It blamed "LocalMachine / GPO", and LocalMachine LOSES to CurrentUser -- it is the lowest-precedence scope of the five, so it can never be what overrode the write. Only the two Group Policy scopes and a Process-scope policy outrank it. The message now names those, distinguishes "the engine answered and the answer still blocks scripts" from "the engine printed nothing at all", and asks the user to read what the manual command reports rather than promising elevation will help.
+
 ## [0.8.24] - 2026-09-11
 
 ### Fixed

--- a/install.ps1
+++ b/install.ps1
@@ -629,18 +629,10 @@ function Assert-InstallLanded {
 }
 
 # --- Pure decision: does this effective policy permit the loader to run? ---
-# EFFECTIVE, and the word is load-bearing: 'Undefined' is what a single SCOPE
-# reads back when nothing was ever written there, and it means "no answer", not
-# "scripts are allowed". An effective `Get-ExecutionPolicy` never returns it --
-# an all-Undefined machine resolves to the platform default, Restricted on
-# Windows clients -- so rejecting it costs nothing here and stops a scoped value
-# that reaches this function by mistake from reading as resolved. It did: the
-# post-check below used to hand it the CurrentUser scope, and a write that never
-# landed was announced as "policy is now Undefined" in green.
 function Test-PolicyResolved {
     param([string]$Policy)
     return (-not [string]::IsNullOrWhiteSpace($Policy)) -and
-           ($Policy.Trim() -notin @('Restricted', 'AllSigned', 'Undefined'))
+           ($Policy.Trim() -notin @('Restricted', 'AllSigned'))
 }
 
 # --- Offer to fix Restricted/AllSigned execution policy for an engine ---
@@ -717,44 +709,21 @@ function Resolve-ExecutionPolicy {
 
     try {
         # Set + re-query in one launch; the last non-empty line is the new policy.
-        #
-        # The re-query carries NO -Scope, and that is the whole of the check.
-        # It used to read back `Get-ExecutionPolicy -Scope CurrentUser` -- the
-        # value it had just written -- while the question this function exists to
-        # answer, and the one the gate above answers from Get-ShellInfo, is the
-        # EFFECTIVE policy. Precedence is MachinePolicy > UserPolicy > Process >
-        # CurrentUser > LocalMachine, so the scoped read-back cannot detect the
-        # failure the pre-check was asking about: with a Group Policy pinning the
-        # machine, `Set-ExecutionPolicy -Scope CurrentUser` SUCCEEDS (it writes
-        # HKCU and only warns that the setting is overridden), the scope reads
-        # back RemoteSigned, and the installer printed a green "Done." on exactly
-        # the machines where the loader still could not run. The write keeps its
-        # scope -- CurrentUser is the one that needs no elevation -- and only the
-        # verification changed. Set-ExecutionPolicy updates the running session
-        # too, so the same launch sees the new effective value.
         $out = & $cmd.Source -NoProfile -NonInteractive -Command `
-            'Set-ExecutionPolicy -Scope CurrentUser RemoteSigned -Force; Get-ExecutionPolicy'
-        $newPolicy = "$(@($out | Where-Object { "$_".Trim() } | Select-Object -Last 1)[0])".Trim()
-        if (Test-PolicyResolved -Policy $newPolicy) {
-            # Names the effective policy, because that is what was verified.
-            Write-Host "    Done. Script execution is now enabled for $Label (effective policy: $newPolicy)." -ForegroundColor Green
+            'Set-ExecutionPolicy -Scope CurrentUser RemoteSigned -Force; Get-ExecutionPolicy -Scope CurrentUser'
+        $newPolicy = @($out | Where-Object { "$_".Trim() } | Select-Object -Last 1)[0]
+        if (Test-PolicyResolved -Policy "$newPolicy") {
+            Write-Host "    Done. CurrentUser policy is now $("$newPolicy".Trim()) for $Label." -ForegroundColor Green
         } else {
-            # Two different failures, and the difference matters: the engine
-            # answered and the answer still blocks scripts, or the engine
-            # printed nothing at all (its own error is on screen above).
-            $verdict = if ($newPolicy) { "is still '$newPolicy'" } else { 'could not be read back' }
-            Write-Host "    The effective policy for $Label $verdict -- the loader cannot run." -ForegroundColor Red
-            # NOT "LocalMachine": that scope loses to CurrentUser and so can
-            # never be what overrode it. Only the two Group Policy scopes and a
-            # Process-scope policy outrank the write above.
-            Write-Host "    A Group Policy (MachinePolicy / UserPolicy) or a Process-scope policy may be overriding CurrentUser." -ForegroundColor Yellow
-            Write-Host "    Ask your administrator, or run this manually and read what it reports:" -ForegroundColor Yellow
+            Write-Host "    The policy did not change (still '$("$newPolicy".Trim())')." -ForegroundColor Red
+            Write-Host "    A machine-wide policy (LocalMachine / GPO) may be blocking CurrentUser overrides." -ForegroundColor Yellow
+            Write-Host "    Run this manually, elevated if needed:" -ForegroundColor Yellow
             Write-Host "      Set-ExecutionPolicy -Scope CurrentUser RemoteSigned" -ForegroundColor Cyan
         }
     } catch {
         Write-Host "    Could not set policy automatically: $_" -ForegroundColor Red
-        Write-Host "    A Group Policy (MachinePolicy / UserPolicy) or a Process-scope policy may be overriding CurrentUser." -ForegroundColor Yellow
-        Write-Host "    Ask your administrator, or run this manually and read what it reports:" -ForegroundColor Yellow
+        Write-Host "    A machine-wide policy (LocalMachine / GPO) may be blocking CurrentUser overrides." -ForegroundColor Yellow
+        Write-Host "    Run this manually, elevated if needed:" -ForegroundColor Yellow
         Write-Host "      Set-ExecutionPolicy -Scope CurrentUser RemoteSigned" -ForegroundColor Cyan
     }
 }

--- a/install.ps1
+++ b/install.ps1
@@ -629,10 +629,18 @@ function Assert-InstallLanded {
 }
 
 # --- Pure decision: does this effective policy permit the loader to run? ---
+# EFFECTIVE, and the word is load-bearing: 'Undefined' is what a single SCOPE
+# reads back when nothing was ever written there, and it means "no answer", not
+# "scripts are allowed". An effective `Get-ExecutionPolicy` never returns it --
+# an all-Undefined machine resolves to the platform default, Restricted on
+# Windows clients -- so rejecting it costs nothing here and stops a scoped value
+# that reaches this function by mistake from reading as resolved. It did: the
+# post-check below used to hand it the CurrentUser scope, and a write that never
+# landed was announced as "policy is now Undefined" in green.
 function Test-PolicyResolved {
     param([string]$Policy)
     return (-not [string]::IsNullOrWhiteSpace($Policy)) -and
-           ($Policy.Trim() -notin @('Restricted', 'AllSigned'))
+           ($Policy.Trim() -notin @('Restricted', 'AllSigned', 'Undefined'))
 }
 
 # --- Offer to fix Restricted/AllSigned execution policy for an engine ---
@@ -709,21 +717,44 @@ function Resolve-ExecutionPolicy {
 
     try {
         # Set + re-query in one launch; the last non-empty line is the new policy.
+        #
+        # The re-query carries NO -Scope, and that is the whole of the check.
+        # It used to read back `Get-ExecutionPolicy -Scope CurrentUser` -- the
+        # value it had just written -- while the question this function exists to
+        # answer, and the one the gate above answers from Get-ShellInfo, is the
+        # EFFECTIVE policy. Precedence is MachinePolicy > UserPolicy > Process >
+        # CurrentUser > LocalMachine, so the scoped read-back cannot detect the
+        # failure the pre-check was asking about: with a Group Policy pinning the
+        # machine, `Set-ExecutionPolicy -Scope CurrentUser` SUCCEEDS (it writes
+        # HKCU and only warns that the setting is overridden), the scope reads
+        # back RemoteSigned, and the installer printed a green "Done." on exactly
+        # the machines where the loader still could not run. The write keeps its
+        # scope -- CurrentUser is the one that needs no elevation -- and only the
+        # verification changed. Set-ExecutionPolicy updates the running session
+        # too, so the same launch sees the new effective value.
         $out = & $cmd.Source -NoProfile -NonInteractive -Command `
-            'Set-ExecutionPolicy -Scope CurrentUser RemoteSigned -Force; Get-ExecutionPolicy -Scope CurrentUser'
-        $newPolicy = @($out | Where-Object { "$_".Trim() } | Select-Object -Last 1)[0]
-        if (Test-PolicyResolved -Policy "$newPolicy") {
-            Write-Host "    Done. CurrentUser policy is now $("$newPolicy".Trim()) for $Label." -ForegroundColor Green
+            'Set-ExecutionPolicy -Scope CurrentUser RemoteSigned -Force; Get-ExecutionPolicy'
+        $newPolicy = "$(@($out | Where-Object { "$_".Trim() } | Select-Object -Last 1)[0])".Trim()
+        if (Test-PolicyResolved -Policy $newPolicy) {
+            # Names the effective policy, because that is what was verified.
+            Write-Host "    Done. Script execution is now enabled for $Label (effective policy: $newPolicy)." -ForegroundColor Green
         } else {
-            Write-Host "    The policy did not change (still '$("$newPolicy".Trim())')." -ForegroundColor Red
-            Write-Host "    A machine-wide policy (LocalMachine / GPO) may be blocking CurrentUser overrides." -ForegroundColor Yellow
-            Write-Host "    Run this manually, elevated if needed:" -ForegroundColor Yellow
+            # Two different failures, and the difference matters: the engine
+            # answered and the answer still blocks scripts, or the engine
+            # printed nothing at all (its own error is on screen above).
+            $verdict = if ($newPolicy) { "is still '$newPolicy'" } else { 'could not be read back' }
+            Write-Host "    The effective policy for $Label $verdict -- the loader cannot run." -ForegroundColor Red
+            # NOT "LocalMachine": that scope loses to CurrentUser and so can
+            # never be what overrode it. Only the two Group Policy scopes and a
+            # Process-scope policy outrank the write above.
+            Write-Host "    A Group Policy (MachinePolicy / UserPolicy) or a Process-scope policy may be overriding CurrentUser." -ForegroundColor Yellow
+            Write-Host "    Ask your administrator, or run this manually and read what it reports:" -ForegroundColor Yellow
             Write-Host "      Set-ExecutionPolicy -Scope CurrentUser RemoteSigned" -ForegroundColor Cyan
         }
     } catch {
         Write-Host "    Could not set policy automatically: $_" -ForegroundColor Red
-        Write-Host "    A machine-wide policy (LocalMachine / GPO) may be blocking CurrentUser overrides." -ForegroundColor Yellow
-        Write-Host "    Run this manually, elevated if needed:" -ForegroundColor Yellow
+        Write-Host "    A Group Policy (MachinePolicy / UserPolicy) or a Process-scope policy may be overriding CurrentUser." -ForegroundColor Yellow
+        Write-Host "    Ask your administrator, or run this manually and read what it reports:" -ForegroundColor Yellow
         Write-Host "      Set-ExecutionPolicy -Scope CurrentUser RemoteSigned" -ForegroundColor Cyan
     }
 }

--- a/tests/Install-Hardening.Tests.ps1
+++ b/tests/Install-Hardening.Tests.ps1
@@ -207,6 +207,17 @@ Describe 'Test-PolicyResolved' {
         Test-PolicyResolved -Policy $null | Should -BeFalse
     }
 
+    It "rejects 'Undefined' -- it is the absence of an answer, not permission" {
+        # An EFFECTIVE Get-ExecutionPolicy never returns it (an all-Undefined
+        # machine resolves to the platform default), so this is the value of a
+        # single SCOPE that was never written. It used to return $true, and the
+        # post-check in Resolve-ExecutionPolicy was handing it the CurrentUser
+        # scope: a write that did not land was announced as
+        # "Done. CurrentUser policy is now Undefined" in green.
+        Test-PolicyResolved -Policy 'Undefined'    | Should -BeFalse
+        Test-PolicyResolved -Policy '  undefined ' | Should -BeFalse
+    }
+
     It 'tolerates surrounding whitespace' {
         Test-PolicyResolved -Policy "  RemoteSigned `r`n" | Should -BeTrue
         Test-PolicyResolved -Policy "  Restricted  "       | Should -BeFalse
@@ -393,5 +404,132 @@ Describe 'the install panel names the engines it actually registered' {
             "$($n.Member.Extent.Text)" -eq 'PSEdition' }, $true))
         @($editionReads).Count | Should -Be 0 `
             -Because 'inverting the edition is what named Windows PowerShell 5.1 on a Mac'
+    }
+}
+
+Describe 'Resolve-ExecutionPolicy verifies the effective policy, not the scope it wrote' {
+    BeforeAll {
+        $script:installPath = Join-Path (Split-Path $PSScriptRoot -Parent) 'install.ps1'
+        $TStylesInstallNoRun = $true
+        . $script:installPath
+
+        # A stand-in engine, never a real one. The only thing
+        # Resolve-ExecutionPolicy asks of an engine is
+        #   & $cmd.Source -NoProfile -NonInteractive -Command '<one string>'
+        # plus the last non-empty line of its stdout -- and a .ps1 path answers
+        # that exactly as powershell.exe does: Get-Command hands back an
+        # ExternalScriptInfo whose .Source is the path, and the three arguments
+        # bind to a param block. Nothing in this suite may launch the real
+        # thing: `Set-ExecutionPolicy -Scope CurrentUser RemoteSigned -Force`
+        # would rewrite the execution policy of the machine running the tests.
+        #
+        # The stub answers the two questions DIFFERENTLY, which is the whole
+        # point of the fix. On a GPO-locked machine the CurrentUser scope reads
+        # back the value just written to it while the EFFECTIVE policy -- the
+        # one that decides whether the loader runs -- is unchanged.
+        function script:New-StubEngine {
+            param(
+                [Parameter(Mandatory)][string]$Name,
+                [Parameter(Mandatory)][string]$Effective,   # answer to `Get-ExecutionPolicy`
+                [Parameter(Mandatory)][string]$CurrentUser  # answer to `... -Scope CurrentUser`
+            )
+            $dir = Join-Path $TestDrive ('engine-' + $Name)
+            New-Item -ItemType Directory -Force -Path $dir | Out-Null
+            $log  = Join-Path $dir 'asked.log'
+            $path = Join-Path $dir 'engine.ps1'
+            # An unrecognised question is answered with a value no branch treats
+            # as success, so changing the shape of the command string without
+            # updating this stub fails the tests instead of quietly passing them.
+            $src = @'
+param([switch]$NoProfile, [switch]$NonInteractive, [string]$Command)
+Add-Content -LiteralPath '{LOG}' -Value "$Command"
+$asked = @("$Command" -split ';')[-1].Trim()
+if     ($asked -match '^Get-ExecutionPolicy$')                       { '{EFFECTIVE}' }
+elseif ($asked -match '^Get-ExecutionPolicy\s+-Scope\s+CurrentUser$') { '{CURRENTUSER}' }
+else                                                                  { 'Restricted' }
+'@
+            $src = $src.Replace('{LOG}', $log).Replace('{EFFECTIVE}', $Effective).Replace('{CURRENTUSER}', $CurrentUser)
+            [System.IO.File]::WriteAllText($path, $src, [System.Text.UTF8Encoding]::new($false))
+            # Resolve-ExecutionPolicy returns at its first line if Get-Command
+            # cannot resolve -Exe, and every assertion below would then be
+            # reading an empty string. Fail here, where the reason is legible.
+            if (-not (Get-Command -Name $path -ErrorAction SilentlyContinue)) {
+                throw "Stub engine '$path' is not resolvable by Get-Command on this platform."
+            }
+            [pscustomobject]@{ Path = $path; Log = $log }
+        }
+
+        # Read with [System.IO.File] and project with @(): an empty log must
+        # count 0, and a missing one must not throw before the assertion runs.
+        function script:Get-EngineCall {
+            param([Parameter(Mandatory)]$Stub)
+            if (-not [System.IO.File]::Exists($Stub.Log)) { return @() }
+            @([System.IO.File]::ReadAllLines($Stub.Log) | Where-Object { "$_".Trim() })
+        }
+    }
+
+    BeforeEach {
+        # There is a human at the console and they answered yes. Without both,
+        # Resolve-ExecutionPolicy returns before it launches anything -- which is
+        # why every case below also counts the calls the stub actually received.
+        Mock Test-InteractiveConsole { $true }
+        Mock Read-Host { 'y' }
+    }
+
+    It 'does not claim success when a Group Policy overrides the CurrentUser write' {
+        # `Set-ExecutionPolicy -Scope CurrentUser` SUCCEEDS under a
+        # MachinePolicy/UserPolicy GPO -- it writes HKCU and only warns -- so the
+        # scope reads back RemoteSigned while the effective policy stays
+        # Restricted and the loader still cannot run. Asking the scope it just
+        # wrote is structurally incapable of detecting that, and the installer
+        # printed "Done. CurrentUser policy is now RemoteSigned" in green on
+        # exactly the machines the prompt exists for.
+        $stub = script:New-StubEngine -Name 'gpo' -Effective 'Restricted' -CurrentUser 'RemoteSigned'
+
+        $out = (Resolve-ExecutionPolicy -Exe $stub.Path -Label 'Windows PowerShell 5.1' `
+                    -EffectivePolicy 'Restricted' 6>&1 | Out-String)
+
+        @(script:Get-EngineCall $stub).Count | Should -Be 1 `
+            -Because 'the engine must actually have been launched, or this test measures nothing'
+        $out | Should -Match 'Script execution is disabled' `
+            -Because 'the prompt path must have been reached'
+        $out | Should -Not -Match 'Done' `
+            -Because 'the loader still cannot run on this machine'
+        # Only the scope-free question can produce this value, whatever the
+        # wording around it.
+        $out | Should -Match "still 'Restricted'"
+        $out | Should -Match 'overriding CurrentUser'
+    }
+
+    It 'does not claim success when the CurrentUser write never lands' {
+        # The other half: when the HKCU write does not stick, the scoped
+        # read-back is the string 'Undefined' -- and the success line then read
+        # "Done. CurrentUser policy is now Undefined", a success claim naming the
+        # word for "nothing is set here", with no error output anywhere.
+        $stub = script:New-StubEngine -Name 'nowrite' -Effective 'Restricted' -CurrentUser 'Undefined'
+
+        $out = (Resolve-ExecutionPolicy -Exe $stub.Path -Label 'Windows PowerShell 5.1' `
+                    -EffectivePolicy 'Restricted' 6>&1 | Out-String)
+
+        @(script:Get-EngineCall $stub).Count | Should -Be 1 `
+            -Because 'the engine must actually have been launched, or this test measures nothing'
+        $out | Should -Not -Match 'Done'
+        $out | Should -Not -Match 'Undefined' `
+            -Because 'Undefined is never an answer worth printing as a result'
+        $out | Should -Match "still 'Restricted'"
+    }
+
+    It 'does claim success when the effective policy really changed' {
+        # The complement, so a fix that simply always reports failure fails here.
+        $stub = script:New-StubEngine -Name 'ok' -Effective 'RemoteSigned' -CurrentUser 'RemoteSigned'
+
+        $out = (Resolve-ExecutionPolicy -Exe $stub.Path -Label 'PowerShell 7' `
+                    -EffectivePolicy 'Restricted' 6>&1 | Out-String)
+
+        @(script:Get-EngineCall $stub).Count | Should -Be 1
+        $out | Should -Match 'Done'
+        $out | Should -Match 'RemoteSigned' `
+            -Because 'the value printed is the one the engine reported'
+        $out | Should -Not -Match 'still'
     }
 }


### PR DESCRIPTION
From the audit ledger (finding 9).

## The defect

`install.ps1` asks "can the loader run?" twice, and asked two different questions.

The **pre-check** reads `Get-ExecutionPolicy` with no scope — the **effective** policy, which is what actually decides whether a script runs. The **post-check** read `Get-ExecutionPolicy -Scope CurrentUser`: the value it had just written.

Precedence is `MachinePolicy > UserPolicy > Process > CurrentUser > LocalMachine`, so the scoped read-back **cannot detect the failure the pre-check was asking about**. With a Group Policy pinning the machine, `Set-ExecutionPolicy -Scope CurrentUser` *succeeds* — it writes HKCU and only warns that the setting is overridden — the scope reads back `RemoteSigned`, and the installer printed a green "Done." on exactly the machines where the loader still could not run.

The write keeps its scope (CurrentUser is the one needing no elevation); only the verification changed.

## Second prong: `Undefined` read as "allowed"

```
policy         Test-PolicyResolved says the loader can run
'Restricted'   False
'AllSigned'    False
'Undefined'    True      <- on main
'RemoteSigned' True
```

`Undefined` is what a single **scope** reads back when nothing was ever written there — it means "no answer", not "allowed". An *effective* `Get-ExecutionPolicy` never returns it, since an all-Undefined machine resolves to the platform default (`Restricted` on Windows clients). So rejecting it costs nothing, and it stops a scoped value arriving by mistake from reading as resolved — which is precisely what the post-check was doing: a write that never landed, announced in green as "policy is now Undefined".

## Third: the failure advice named the wrong culprit

The old message blamed "LocalMachine / GPO". **LocalMachine loses to CurrentUser** — it is the lowest-precedence scope of the five, so it can never be what overrode the write. Confirmed against `Get-ExecutionPolicy -List`, which enumerates in precedence order with LocalMachine last.

It now names the scopes that *can* outrank it, distinguishes "the engine answered and the answer still blocks scripts" from "the engine printed nothing at all", and asks the user to read what the manual command reports rather than promising elevation will help.

## What is NOT verified

**This is Windows-only behaviour and I am on macOS.** `Test-PolicyResolved` is pure and I exercised it directly (table above), and the precedence order is confirmed from the engine. The end-to-end behaviour — that `Set-ExecutionPolicy -Scope CurrentUser` succeeds-with-a-warning under a GPO, and that the unscoped re-query then reports the blocked effective policy — is **reasoned from documented precedence, not observed**. The implementer drove the shipped function against stub engines; nobody has run it on a real Group-Policy-managed box. Worth one real-world check before relying on it.

## Note on this branch's history

An earlier commit of mine accidentally reverted `install.ps1`: I had used `git checkout origin/main -- install.ps1` to measure the before/after, and that **stages** the file, so my subsequent changelog commit carried main's version along with it. Restored from the original implementation commit; the branch now carries the fix, the tests and the changelog together. Full suite green at 1658.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4UptB5S567PxKmMdyH8T1
