### PR TITLE
ci: bound the Pester version, and notice a forgotten release without needing a key

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,89 @@
+# Publish to PSGallery when a version tag is pushed.
+#
+# WHY THIS EXISTS. Publishing was a manual `scripts/publish.ps1` on someone's
+# laptop, and the consequence was not hypothetical: v0.8.22 and v0.8.23 were
+# both committed, tagged and released on GitHub, and neither ever reached
+# PSGallery. Every fix in them -- including a `tstyles reset` that deleted
+# profile settings the user had made by hand, and a trash sweep that erased
+# styles seconds after promising to keep them for seven days -- sat in git for
+# weeks while every installed copy stayed on 0.8.21. A release that does not
+# publish itself is a release nobody gets.
+#
+# SETUP REQUIRED, ONCE. This workflow does nothing until the repository has a
+# PSGALLERY_API_KEY secret:
+#   Settings -> Secrets and variables -> Actions -> New repository secret
+#   Name: PSGALLERY_API_KEY   Value: your PSGallery API key
+# Without it the job stops at the guard below and says so, rather than failing
+# somewhere deeper with a less obvious message.
+
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+  # Deliberate: a tag that was pushed before this workflow existed, or one whose
+  # publish failed and was fixed, can be published without inventing a new tag.
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Tag to publish (e.g. v0.8.24)'
+        required: true
+
+jobs:
+  publish:
+    name: Publish to PSGallery
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+          # publish.ps1 resolves every allowlist entry through `git ls-files`,
+          # so it needs real history, not a blobless checkout.
+          fetch-depth: 0
+
+      - name: Refuse early if the key is not configured
+        shell: pwsh
+        env:
+          KEY: ${{ secrets.PSGALLERY_API_KEY }}
+        run: |
+          if (-not $env:KEY) {
+            Write-Host "::error::PSGALLERY_API_KEY is not set on this repository."
+            Write-Host "Add it under Settings -> Secrets and variables -> Actions."
+            Write-Host "Nothing was published and nothing was staged."
+            exit 1
+          }
+          Write-Host "API key is present."
+
+      - name: The tag must match the manifest version
+        shell: pwsh
+        run: |
+          # A tag and a ModuleVersion that disagree is the one mistake this
+          # workflow can make that a human cannot undo: PSGallery does not
+          # allow republishing a version. Better to fail here than to ship
+          # 0.8.23's code as 0.8.24.
+          $tag = "${{ github.event.inputs.ref || github.ref_name }}" -replace '^v', ''
+          $manifest = (Test-ModuleManifest ./TerminalStyles.psd1).Version.ToString()
+          Write-Host "tag: $tag   manifest: $manifest"
+          if ($tag -ne $manifest) {
+            Write-Host "::error::Tag $tag does not match ModuleVersion $manifest."
+            exit 1
+          }
+
+      - name: Stage and verify without publishing
+        shell: pwsh
+        run: |
+          # publish.ps1 -WhatIf stages the allowlist, validates the manifest and
+          # smoke-tests that the staged module imports and every shipped
+          # function resolves -- all before the key is used for anything.
+          ./scripts/publish.ps1 -WhatIf
+
+      - name: Publish
+        shell: pwsh
+        env:
+          PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}
+        run: |
+          # Passed as a parameter rather than left in the environment for the
+          # publish step to find: publish.ps1 prompts when it is not given one,
+          # and a prompt on a runner is a hang, not a failure.
+          ./scripts/publish.ps1 -ApiKey $env:PSGALLERY_API_KEY

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,29 +1,28 @@
-# Publish to PSGallery when a version tag is pushed.
+# Publish to PSGallery, by hand, from here.
 #
-# WHY THIS EXISTS. Publishing was a manual `scripts/publish.ps1` on someone's
-# laptop, and the consequence was not hypothetical: v0.8.22 and v0.8.23 were
-# both committed, tagged and released on GitHub, and neither ever reached
-# PSGallery. Every fix in them -- including a `tstyles reset` that deleted
-# profile settings the user had made by hand, and a trash sweep that erased
-# styles seconds after promising to keep them for seven days -- sat in git for
-# weeks while every installed copy stayed on 0.8.21. A release that does not
-# publish itself is a release nobody gets.
+# NOT THE PRIMARY PATH, and deliberately not automatic. The PSGallery API key
+# for this project rotates, so a stored PSGALLERY_API_KEY secret goes stale
+# between releases and a tag-triggered publish would fail more often than it
+# worked. The local `pwsh ./scripts/publish.ps1` -- which prompts for the key
+# with hidden input and writes it to neither history nor env -- stays the way
+# releases ship.
 #
-# SETUP REQUIRED, ONCE. This workflow does nothing until the repository has a
-# PSGALLERY_API_KEY secret:
-#   Settings -> Secrets and variables -> Actions -> New repository secret
-#   Name: PSGALLERY_API_KEY   Value: your PSGallery API key
-# Without it the job stops at the guard below and says so, rather than failing
-# somewhere deeper with a less obvious message.
+# What catches a forgotten release is release-drift.yml, which compares the
+# newest tag against PSGallery's PUBLIC version and needs no key at all. That
+# is the workflow that matters; this one is here for the case where a key IS
+# current, and it is dispatch-only so it never fires on a tag with a stale one.
+#
+# To use it: add a PSGALLERY_API_KEY secret (Settings -> Secrets and variables
+# -> Actions), then run this workflow against the tag. Without the secret it
+# stops at the first guard and says so.
 
 name: Publish
 
+# Dispatch only. A tag push must not attempt a publish with a key that has
+# very likely rotated since it was stored -- a red X on every release would
+# train everyone to ignore it, and release-drift.yml is what should speak up
+# on a tag instead.
 on:
-  push:
-    tags:
-      - 'v*'
-  # Deliberate: a tag that was pushed before this workflow existed, or one whose
-  # publish failed and was fixed, can be published without inventing a new tag.
   workflow_dispatch:
     inputs:
       ref:
@@ -37,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.inputs.ref || github.ref }}
+          ref: ${{ github.event.inputs.ref }}
           # publish.ps1 resolves every allowlist entry through `git ls-files`,
           # so it needs real history, not a blobless checkout.
           fetch-depth: 0
@@ -62,7 +61,7 @@ jobs:
           # workflow can make that a human cannot undo: PSGallery does not
           # allow republishing a version. Better to fail here than to ship
           # 0.8.23's code as 0.8.24.
-          $tag = "${{ github.event.inputs.ref || github.ref_name }}" -replace '^v', ''
+          $tag = "${{ github.event.inputs.ref }}" -replace '^v', ''
           $manifest = (Test-ModuleManifest ./TerminalStyles.psd1).Version.ToString()
           Write-Host "tag: $tag   manifest: $manifest"
           if ($tag -ne $manifest) {

--- a/.github/workflows/release-drift.yml
+++ b/.github/workflows/release-drift.yml
@@ -1,0 +1,72 @@
+# Is the newest tag actually on PSGallery?
+#
+# WHY THIS EXISTS, AND WHY IT NEEDS NO SECRET. Publishing is a local
+# `scripts/publish.ps1` run, and the API key rotates, so it cannot be stored
+# here and the publish cannot be automated. That is fine -- automating the
+# publish was never the real fix. The real failure was not knowing: v0.8.22 and
+# v0.8.23 were both committed, tagged and released on GitHub, and neither ever
+# reached PSGallery. Every installed copy stayed on 0.8.21 for weeks while a
+# `tstyles reset` that deleted hand-made profile settings, and a trash sweep
+# that erased styles seconds after promising seven days, sat fixed in git and
+# shipped to nobody. Nothing anywhere said so.
+#
+# PSGallery's published version is PUBLIC. This asks for it, compares it to the
+# newest tag, and fails when they differ -- on the tag push itself, and again
+# every Monday for as long as it stays true. No key, no secret, nothing to
+# rotate.
+
+name: Release drift
+
+on:
+  push:
+    tags:
+      - 'v*'
+  schedule:
+    # Monday 09:00 UTC. A weekly nag is the right frequency for something whose
+    # fix is one command: often enough that a forgotten release is caught in
+    # days, rare enough that the mail still gets read.
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+jobs:
+  drift:
+    name: Tag vs PSGallery
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0   # tags
+
+      - name: Compare the newest tag with what PSGallery serves
+        shell: pwsh
+        run: |
+          $tag = (git tag -l --sort=-v:refname | Select-Object -First 1)
+          if (-not $tag) { Write-Host "No tags yet; nothing to compare."; exit 0 }
+          $tagVersion = $tag -replace '^v', ''
+
+          # Read-only, unauthenticated, and allowed to fail: PSGallery being
+          # unreachable is not a release problem and must not read as one.
+          try {
+              $published = (Find-PSResource -Name TerminalStyles -Repository PSGallery -ErrorAction Stop).Version.ToString()
+          } catch {
+              Write-Host "::warning::Could not reach PSGallery: $($_.Exception.Message)"
+              Write-Host "Not treating this as drift."
+              exit 0
+          }
+
+          Write-Host "newest tag : $tagVersion"
+          Write-Host "PSGallery  : $published"
+
+          if ([version]$published -ge [version]$tagVersion) {
+              Write-Host "PSGallery is up to date."
+              exit 0
+          }
+
+          Write-Host "::error::PSGallery is on $published but the newest tag is $tagVersion -- the release has not shipped."
+          Write-Host ""
+          Write-Host "Nobody is running the fixes in $tagVersion. To publish, from a checkout of the tag:"
+          Write-Host "    pwsh ./scripts/publish.ps1"
+          Write-Host "It prompts for the API key with hidden input and writes it to neither history nor env."
+          Write-Host ""
+          Write-Host "This check runs again every Monday until the two agree."
+          exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install Pester 5 (PSResourceGet)
+      - name: Install Pester (PSResourceGet)
         if: matrix.shell == 'pwsh'
         shell: pwsh
         run: |
@@ -37,11 +37,23 @@ jobs:
           # repos and dependency resolution more reliably than the legacy
           # PowerShellGet v2 Install-Module, which has been flaky for
           # 'No match was found' errors against PSGallery on CI runners.
-          Install-PSResource -Name Pester -Version '[5.0.0,)' -TrustRepository -Reinstall
+          # BOUNDED ABOVE on purpose. This was '[5.0.0,)', which is "newest", so
+          # the major version of the test framework arrived from whatever
+          # PSGallery happened to be serving that day -- and it moved: the step
+          # was still called "Install Pester 5" while these legs ran Pester 6.
+          # That is not cosmetic. Pester 6 discovers and executes each file in
+          # turn rather than discovering all of them first, which silently made
+          # a guard that watches for tests writing to the operator's own files
+          # compare the damage against itself; and it FAILS DISCOVERY on an
+          # empty -ForEach rather than producing no tests, which took both
+          # Windows legs down for a file about POSIX shells. Both were found by
+          # hand, not by this workflow. A new major is now a decision someone
+          # makes here, not something that happens to a Tuesday.
+          Install-PSResource -Name Pester -Version '[5.0.0,7.0.0)' -TrustRepository -Reinstall
           Import-Module Pester
           (Get-Module Pester).Version
 
-      - name: Install Pester 5 (Windows PowerShell)
+      - name: Install Pester (Windows PowerShell)
         if: matrix.shell == 'powershell'
         shell: powershell
         run: |
@@ -53,7 +65,12 @@ jobs:
             [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
           Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force | Out-Null
           Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-          Install-Module -Name Pester -MinimumVersion 5.0.0 -Force -SkipPublisherCheck -Scope CurrentUser
+          # Same upper bound as the PSResourceGet leg above; -MinimumVersion
+          # alone is "newest" and would let the two engines drift onto
+          # different majors, which is the one thing a two-engine matrix must
+          # not do quietly.
+          Install-Module -Name Pester -MinimumVersion 5.0.0 -MaximumVersion 6.99.99 `
+            -Force -SkipPublisherCheck -Scope CurrentUser
           Import-Module Pester -MinimumVersion 5.0.0
           (Get-Module Pester).Version
 
@@ -112,13 +129,13 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y zsh
 
-      - name: Install Pester 5
+      - name: Install Pester
         shell: pwsh
         run: |
           # -Repository PSGallery explicitly: the runner images register
           # additional repositories, and resolution against the wrong one fails
           # with a bare "package: Not Found".
-          Install-PSResource -Name Pester -Version '[5.0.0,)' -Repository PSGallery -TrustRepository -Reinstall
+          Install-PSResource -Name Pester -Version '[5.0.0,7.0.0)' -Repository PSGallery -TrustRepository -Reinstall
           Import-Module Pester
           (Get-Module Pester).Version
 


### PR DESCRIPTION
Two CI problems, both invisible until they cost something.

## 1. The test framework's major version was arriving by accident

Every Pester install line was unbounded above — `-Version '[5.0.0,)'` and `-MinimumVersion 5.0.0` both mean **newest**. So steps named *"Install Pester 5"* have been running:

```
Pester (Windows PowerShell 5.1)   Major  Minor  Build
                                  6      2      0
```

Not cosmetic. Pester 6 changed two semantics, and both cost us this week:

- **It discovers and executes each file in turn** rather than discovering all first — which silently made the guard that watches for tests writing to the operator's own files photograph the state *after* the damage and compare it against itself. An inert guard, reporting green.
- **It fails DISCOVERY on an empty `-ForEach`** rather than producing no tests, taking *both* Windows legs down for a file about POSIX shells.

Both found by hand, neither by this workflow. Now bounded at `7.0.0` on all three install sites, with a matching `-MaximumVersion` on the Windows PowerShell leg so the two engines cannot drift onto different majors. Steps renamed to what they do.

*(`#Requires -Modules @{ModuleVersion='5.0.0'}` in the test files is left alone — it is a floor, and 6 satisfies it honestly.)*

## 2. A forgotten release was invisible — and the fix needs no key

**v0.8.22 and v0.8.23 were both committed, tagged and released on GitHub, and neither ever reached PSGallery.** Every installed copy stayed on 0.8.21 for weeks while a `tstyles reset` that deleted hand-made profile settings, and a trash sweep that erased styles seconds after promising seven days, sat fixed in git and shipped to nobody. Nothing anywhere said so.

My first attempt automated the publish behind a stored `PSGALLERY_API_KEY`. **That was the wrong design here: the key rotates**, so the secret goes stale between releases and a tag-triggered publish would fail more often than it worked — and a red X on every release trains everyone to ignore it, which is worse than no check at all.

Automating the publish was never the real fix. The real failure was *not knowing*.

**`release-drift.yml`** asks PSGallery for its published version — which is **public**, no key, nothing to rotate — compares it with the newest tag, and fails when they differ. On the tag push itself, and again every Monday for as long as it stays true. Verified against the current state, which is exactly the condition it exists to report:

```
newest tag : 0.8.24
PSGallery  : 0.8.21
-> DRIFT: "PSGallery is on 0.8.21 but the newest tag is 0.8.24"
```

The failure message names the one command that fixes it. An unreachable PSGallery warns and exits 0 — a network failure is not a release problem and must not read as one.

**`publish.yml`** stays but is demoted to `workflow_dispatch` only, for the case where a key *is* current. It no longer fires on a tag. Its guards are unchanged: refuses without the secret, refuses when the tag and `ModuleVersion` disagree (PSGallery does not allow republishing a version — the one unfixable mistake here), and stages + smoke-tests via `-WhatIf` before the key is used for anything.

## What this asks of you

Nothing. No secret required for the drift check. The first thing it will do once merged is tell you 0.8.24 is unpublished — which it is.

Full suite: 1654 passed, 11 skipped. No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4UptB5S567PxKmMdyH8T1
