### PR TITLE
fix(settings): applying to 'defaults' deleted your settings.json comments and reported success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **applying a style to the `defaults` profile deleted every comment in `settings.json`, wrote nothing of the style, and printed "Style applied" in green.** `Resolve-WTProfileTarget` returned `Ok = $true` for `defaults` unconditionally, on the reasoning that the block does not have to exist yet because an apply creates it lazily. It creates it with `$Settings.profiles | Add-Member`, which has nothing to add to unless `profiles` is a JSON object -- and a hand-minimised `settings.json` may have no `profiles` key, `"profiles": null` parses to nothing, and a truncated write leaves a zero-byte file. So `Apply-StyleDirect`'s guard passed, the rolling `.bak` was spent, and the merge threw "You cannot call a method on a null-valued expression".
+
+  A method call on `$null` aborts the STATEMENT, not the script, and `$ErrorActionPreference` is `Continue` interactively -- so `$settings` kept the parsed-but-unmerged object and the very next line wrote it out. The user's comments were gone, the style was in no profile, and `tstyles current` named it anyway. This is precisely the failure the `-Target` guard was added to prevent -- "a misspelled profile name silently and irreversibly deleted their JSONC comments" -- re-entered through the one target the resolver declared always addressable. Worse on the second run: run 1 leaves the good file in the `.bak`, run 2 copies the stripped one over it. On a zero-byte `settings.json` the backup step overwrites the `.bak` with the empty file while printing "Backed up settings to: ...".
+
+  The legacy flat form `"profiles": [ ... ]` fails differently and silently: `Add-Member` UNROLLS an array, so the whole theme was grafted onto the first profile object, where Windows Terminal ignores it, and the resolver advertised "Available: defaults" while naming none of the user's real profiles. Measured against the shipped function:
+
+  ```
+  shape              main                              fixed
+  no profiles key    throws -> comments deleted        returns, writes nothing
+  legacy array       grafts defaults onto a profile    does not
+  ```
+
+  `Get-WTProfileShape` now answers "what is `profiles`, and what may a target name" once, and the four readers that had each assumed the modern shape consult it: the resolver for `Ok` and `Available`, `Merge-StyleIntoSettings` and `Set-ProfileFont` for their lazy creation, and reset's orphan-scheme sweep. The slot test is structural rather than a type name, so it answers the same on both engines. Named targets in the array form now resolve and merge correctly, which meant fixing reset's `stillUsed` computation in the same change -- reachable profiles it could not previously see would otherwise have let a reset delete a scheme still in use.
+
+  `Apply-StyleDirect` also no longer writes when the merge did not come back. That guard is what separates an ugly error from silent comment loss, and it will do the same for the next throw inside the merge.
+
+- **only `tstyles <style>` warned that a profile name was duplicated; the picker, reset, font, tune and `apply.ps1` all resolved one silently.** `Ambiguous` had two producers and exactly one consumer, across eleven call sites. The note is now written in one place that every caller reads, and the resolver records HOW it broke the tie rather than letting the note re-derive it -- so it no longer claims "the one this session is running in" when `WT_PROFILE_ID` names a third profile and file order actually decided.
+
 ## [0.8.24] - 2026-09-11
 
 ### Fixed

--- a/apply.ps1
+++ b/apply.ps1
@@ -126,13 +126,25 @@ Write-Host "Settings file: $SettingsPath"
 $settings = ConvertFrom-WTJson ([System.IO.File]::ReadAllText($SettingsPath, [System.Text.UTF8Encoding]::new($false)))
 
 # --- Target profile selection ---
-$profileNames = @('defaults') + @($settings.profiles.list | ForEach-Object { $_.name })
+# The module's own list, not a fork of it. Built here by hand it always offered
+# 'defaults' -- including for a settings.json with no `profiles` object to
+# create one on, which is the answer the check below is now guaranteed to
+# refuse.
+$profileNames = @((Get-WTProfileShape -Settings $settings).Available)
+if (-not $profileNames.Count) {
+    # Asked before the prompt, because a menu of nothing is not a question.
+    throw (Get-WTTargetNotFoundMessage -ResolvedTarget $null -TargetName $Target)
+}
 if (-not $Target) {
     $Target = Read-Choice 'Which Windows Terminal profile to apply this style to?' $profileNames -Flag '-Target'
 }
-if (-not (Resolve-WTProfileTarget -Settings $settings -TargetName $Target).Ok) {
-    throw "Profile '$Target' not found. Available: $($profileNames -join ', ')"
+$resolvedTarget = Resolve-WTProfileTarget -Settings $settings -TargetName $Target
+if (-not $resolvedTarget.Ok) {
+    throw (Get-WTTargetNotFoundMessage -ResolvedTarget $resolvedTarget -TargetName $Target)
 }
+# Two profiles can share a name, and this script picked one of them in silence.
+# Same note the module's apply path prints.
+Write-AmbiguousTargetNote -ResolvedTarget $resolvedTarget -TargetName $Target -Verb 'Applied to'
 Write-Host "Target: $Target" -ForegroundColor Green
 
 # --- Background image ---

--- a/lib/applystyle.ps1
+++ b/lib/applystyle.ps1
@@ -632,20 +632,15 @@ function Apply-StyleDirect {
     # irreversibly deleted their JSONC comments.
     $resolvedTarget = Resolve-WTProfileTarget -Settings $settings -TargetName $Target
     if (-not $resolvedTarget.Ok) {
-        Write-Error ("Windows Terminal profile '$Target' not found. Available: " +
-                     ($resolvedTarget.Available -join ', '))
+        Write-Error (Get-WTTargetNotFoundMessage -ResolvedTarget $resolvedTarget -TargetName $Target)
         return
     }
 
-    # Say so when the name was not unique. The resolver breaks the tie with the
-    # session's own GUID, which is almost always what the user wants -- but
-    # "almost always" is worth one line, because the alternative is a silent
-    # choice between two profiles the user cannot tell apart from the outside.
-    # Without this, Ambiguous would be a field nothing reads.
-    if ($resolvedTarget.Ambiguous) {
-        Write-Host "  Note: more than one profile is named '$Target'." -ForegroundColor DarkGray
-        Write-Host "  Applied to the one this session is running in." -ForegroundColor DarkGray
-    }
+    # Say so when the name was not unique -- through the shared note, which is
+    # the same sentence reset, font, the picker and apply.ps1 now print. This
+    # was the only caller that said anything, and it was the inline version that
+    # claimed the session's profile even when the tie could not be broken.
+    Write-AmbiguousTargetNote -ResolvedTarget $resolvedTarget -TargetName $Target -Verb 'Applied to'
 
     # The style half of the same rule. Merge-StyleIntoSettings returns the
     # settings UNTOUCHED for a style with no theme.json -- deliberately, since a
@@ -676,9 +671,31 @@ function Apply-StyleDirect {
             Write-Host "Warning: could not write backup ($_); proceeding anyway." -ForegroundColor Yellow
         }
 
-        $settings = Merge-StyleIntoSettings -Settings $settings -StyleDir $styleDir `
-            -TargetName $Target -BackgroundImage $BackgroundImage `
-            -BackgroundImageProvided $BackgroundImageProvided
+        # Into a SEPARATE variable, and checked before the write. This was
+        # `$settings = Merge-...` followed by the write, and PowerShell does not
+        # abandon the command when the merge fails: a method call on a
+        # null-valued expression aborts only that STATEMENT, and
+        # $ErrorActionPreference is 'Continue' in an interactive shell. So the
+        # assignment never happened, $settings still held the parsed-but-
+        # unmerged object, and Write-SettingsFile re-serialized THAT -- which
+        # deleted every JSONC comment in the user's settings.json, printed
+        # "Style applied" in green, and recorded a style no profile had
+        # received. That is the exact failure the -Target guard above exists to
+        # prevent; it came back through the merge. The resolver no longer hands
+        # this path a target the merge cannot write, and this makes sure the
+        # next throw inside the merge costs an error message instead of the
+        # user's comments.
+        $merged = $null
+        try {
+            $merged = Merge-StyleIntoSettings -Settings $settings -StyleDir $styleDir `
+                -TargetName $Target -BackgroundImage $BackgroundImage `
+                -BackgroundImageProvided $BackgroundImageProvided
+        } catch {
+            $merged = $null
+            Write-Error "Could not apply '$StyleName' to '$Target': $_"
+        }
+        if ($null -eq $merged) { return }
+        $settings = $merged
         Write-SettingsFile -Path $settingsPath -Settings $settings
     }
 
@@ -816,6 +833,14 @@ function Reset-StyleDirect {
         return
     }
 
+    # Reset needs this note more than apply does, and never had it. The strip
+    # below removes every field an apply may write -- padding, opacity,
+    # useAcrylic, cursorShape, font.face and the rest -- off whichever of two
+    # same-named profiles the resolver picked, and then reports "Reset '<name>'
+    # to its unstyled default." in green. Which one it picked is not something
+    # the user can see from the outside.
+    Write-AmbiguousTargetNote -ResolvedTarget $resolvedTarget -TargetName $Target -Verb 'Reset'
+
     # Capture the scheme name before stripping (for orphan cleanup).
     $schemeName = if ($entry.PSObject.Properties.Match('colorScheme').Count) { $entry.colorScheme } else { $null }
 
@@ -874,9 +899,18 @@ function Reset-StyleDirect {
 
     # Remove the orphan scheme unless another profile still references it.
     if ($schemeName -and $settings.PSObject.Properties.Match('schemes').Count) {
+        # "Every profile that could still reference this scheme" has to mean the
+        # same set the resolver targets, or the sweep deletes a scheme something
+        # still uses. Through the shared shape for that reason: a direct read of
+        # .list finds nothing on the legacy flat-array form, where the profiles
+        # are the array itself -- and those profiles are now resolvable, so
+        # reset can reach them.
+        $shape = Get-WTProfileShape -Settings $settings
         $allProfiles = @()
-        if ($settings.profiles.PSObject.Properties.Match('defaults').Count) { $allProfiles += $settings.profiles.defaults }
-        $allProfiles += @($settings.profiles.list)
+        if ($shape.HasDefaultsSlot -and $settings.profiles.PSObject.Properties.Match('defaults').Count) {
+            $allProfiles += $settings.profiles.defaults
+        }
+        $allProfiles += @($shape.List)
         $stillUsed = @($allProfiles | Where-Object {
             $_.PSObject.Properties.Match('colorScheme').Count -and $_.colorScheme -eq $schemeName
         }).Count -gt 0

--- a/lib/fonts.ps1
+++ b/lib/fonts.ps1
@@ -492,6 +492,12 @@ function Set-ProfileFont {
 
     $entry = $null
     if ($TargetName -eq 'defaults') {
+        # Same guard, same reason, as the merge's lazy creation: Add-Member has
+        # nothing to add `defaults` to unless `profiles` is an object, and on
+        # the legacy flat-array form it silently grafts the block onto every
+        # profile instead. $false is the answer this function already has for "a
+        # target that is not there", and it leaves settings.json untouched.
+        if (-not (Get-WTProfileShape -Settings $settings).HasDefaultsSlot) { return $false }
         if (-not $settings.profiles.PSObject.Properties.Match('defaults').Count) {
             $settings.profiles | Add-Member -NotePropertyName defaults -NotePropertyValue ([pscustomobject]@{})
         }
@@ -609,9 +615,16 @@ function Invoke-TerminalStyleFont {
     # user's undo of their last real apply on a command that changed nothing.
     $resolvedTarget = Resolve-WTProfileTarget -Settings $settingsObj -TargetName $Target
     if (-not $resolvedTarget.Ok) {
-        Write-Host "Profile '$Target' not found in settings.json. Available: $($resolvedTarget.Available -join ', ')" -ForegroundColor Yellow
+        Write-Host (Get-WTTargetNotFoundMessage -ResolvedTarget $resolvedTarget -TargetName $Target) -ForegroundColor Yellow
         return
     }
+
+    # The same tie, the same note as apply and reset. Set-ProfileFont resolves
+    # again internally and gets the same answer; this is the one place that can
+    # say so, and it said nothing -- so the font landed on whichever of two
+    # same-named profiles came first and "Applied '<font>' to '<name>'" printed
+    # in green either way.
+    Write-AmbiguousTargetNote -ResolvedTarget $resolvedTarget -TargetName $Target -Verb 'Applied to'
 
     try { Save-SettingsBackup -Path $settingsPath -ResolvedTarget $resolvedTarget -Quiet } catch { }
     if (Set-ProfileFont -SettingsPath $settingsPath -TargetName $Target -Family $font.family) {

--- a/lib/wtsettings.ps1
+++ b/lib/wtsettings.ps1
@@ -249,6 +249,78 @@ function Get-StyleSettingsPayload {
     return [pscustomobject]@{ Ok = $true; Missing = $null }
 }
 
+function Get-WTProfileShape {
+    <#
+    .SYNOPSIS
+    What `profiles` actually is in this settings.json, and what a -Target may name.
+
+    .DESCRIPTION
+    Windows Terminal writes `"profiles": { "defaults": {...}, "list": [...] }`
+    and every read here assumed it. Files in the wild are not always that shape:
+    a hand-minimised settings.json can have no `profiles` key at all,
+    `"profiles": null` parses to nothing, an interrupted or truncated write
+    leaves a zero-byte file (so $Settings ITSELF is $null), and the legacy flat
+    form `"profiles": [ ... ]` is an array.
+
+    HasDefaultsSlot is the load-bearing one, because 'defaults' is the single
+    target that does not have to exist yet: an apply creates the block lazily
+    with `$Settings.profiles | Add-Member`. That has nothing to add to unless
+    `profiles` is a JSON object. Against a missing key or a null it throws "You
+    cannot call a method on a null-valued expression"; against the array form it
+    is worse and does not throw at all, because Add-Member UNROLLS an array and
+    grafts a `defaults` NoteProperty onto every profile IN it -- so the whole
+    theme is written inside the first profile, where Windows Terminal ignores it.
+
+    One question, four readers -- Resolve-WTProfileTarget decides Ok and
+    Available from it, Merge-StyleIntoSettings and Set-ProfileFont guard their
+    lazy creation with it, Reset-StyleDirect enumerates profiles with it.
+    Sharing it is the point: the resolver answering "yes, addressable" while the
+    merge assumed a shape the file did not have is what spent the user's rolling
+    backup and then wrote a comment-stripped settings.json back over their own
+    file, under "Style applied" in green.
+
+    ConvertFrom-Json gives a PSCustomObject for `{...}` and an Object[] for
+    `[...]`, on pwsh 7 and Windows PowerShell 5.1 alike. The test below asks the
+    question structurally rather than by type name -- "is this something a
+    member can be hung on", i.e. not null, not a collection, not a scalar --
+    because that is the property the lazy creation actually depends on. (Testing
+    `-is [pscustomobject]` would be wrong anyway: that accelerator is
+    System.Management.Automation.PSObject, which the parsed object is not.)
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][AllowNull()]$Settings)
+
+    $profiles = $null
+    try { $profiles = $Settings.profiles } catch { $profiles = $null }
+
+    $hasSlot = ($null -ne $profiles -and
+                $profiles -isnot [System.Collections.IEnumerable] -and
+                $profiles -isnot [System.ValueType])
+
+    $list = @()
+    if ($hasSlot) {
+        # @($null) is a one-element array holding $null, not an empty one, so a
+        # profiles object with no `list` key would otherwise report one profile.
+        $list = @($profiles.list | Where-Object { $null -ne $_ })
+    } elseif ($profiles -is [array]) {
+        $list = @($profiles | Where-Object { $null -ne $_ })
+    }
+
+    # What the user may pass to -Target, in the order they should see it.
+    # 'defaults' is listed only where it can actually be written: offering it
+    # for a file that cannot carry it is the error message promising the one
+    # answer that is guaranteed to fail.
+    $available = @()
+    if ($hasSlot) { $available += 'defaults' }
+    $available += @($list | ForEach-Object { $_.name } | Where-Object { $_ })
+
+    return [pscustomobject]@{
+        HasDefaultsSlot = $hasSlot
+        List            = $list
+        Available       = $available
+    }
+}
+
 function Resolve-WTProfileTarget {
     <#
     .SYNOPSIS
@@ -260,14 +332,20 @@ function Resolve-WTProfileTarget {
     damage -- which is how a mistyped -Target came to destroy the rolling
     backup on two of them while erroring cleanly on a third.
 
-    Ok vs Entry is a real distinction, not a convenience. 'defaults' is always
-    ADDRESSABLE (an apply creates the block lazily) so Ok is $true, but it has
-    no Entry until the block exists -- and reset has nothing to strip from a
-    profile that is not there. Callers that write want Ok; callers that modify
-    an existing entry want Entry.
+    Ok vs Entry is a real distinction, not a convenience. 'defaults' is
+    ADDRESSABLE without existing (an apply creates the block lazily) so Ok can be
+    $true with no Entry -- and reset has nothing to strip from a profile that is
+    not there. Callers that write want Ok; callers that modify an existing entry
+    want Entry. Addressable is not unconditional, though: it needs a `profiles`
+    object to create the block on, which is Get-WTProfileShape's question.
 
     Available is for the caller's error message, so every one of them can name
     the same set of real profiles.
+
+    TieBreak says HOW a duplicated name was resolved, because the caller has to
+    tell the user: 'Session' when $PreferGuid picked one of the namesakes,
+    'First' when it could not and the file order decided. It is $null exactly
+    when Ambiguous is $false.
     #>
     [CmdletBinding()]
     param(
@@ -281,18 +359,35 @@ function Resolve-WTProfileTarget {
         [AllowEmptyString()][string]$PreferGuid = $env:WT_PROFILE_ID
     )
 
-    $list = @()
-    try { $list = @($Settings.profiles.list) } catch { $list = @() }
-    $available = @('defaults') + @($list | ForEach-Object { $_.name } | Where-Object { $_ })
+    $shape     = Get-WTProfileShape -Settings $Settings
+    $list      = $shape.List
+    $available = $shape.Available
 
     if ($TargetName -eq 'defaults') {
+        # Ok was $true here UNCONDITIONALLY, and that is the whole of the defect
+        # this guard closes. Apply-StyleDirect's -Target guard asks this
+        # question, so it passed for a settings.json with no `profiles` object;
+        # the rolling backup was spent; Merge-StyleIntoSettings then threw "You
+        # cannot call a method on a null-valued expression" on the lazy
+        # creation. A method call on null aborts the STATEMENT, not the command,
+        # so the assignment never happened, $settings still held the
+        # parsed-but-unmerged object, and the write on the next line re-
+        # serialized it: every JSONC comment in the user's file deleted, "Style
+        # applied" in green, and no profile touched. Run it twice and the .bak
+        # -- the one copy that still had the comments -- was overwritten with
+        # the stripped file. See Get-WTProfileShape for the four shapes.
         $entry = $null
-        try {
-            if ($Settings.profiles.PSObject.Properties.Match('defaults').Count) {
-                $entry = $Settings.profiles.defaults
-            }
-        } catch { }
-        return [pscustomobject]@{ Ok = $true; Entry = $entry; IsDefaults = $true; Available = $available; Ambiguous = $false }
+        if ($shape.HasDefaultsSlot -and $Settings.profiles.PSObject.Properties.Match('defaults').Count) {
+            $entry = $Settings.profiles.defaults
+        }
+        return [pscustomobject]@{
+            Ok         = $shape.HasDefaultsSlot
+            Entry      = $entry
+            IsDefaults = $true
+            Available  = $available
+            Ambiguous  = $false
+            TieBreak   = $null
+        }
     }
 
     # NOT $matches: that is an AUTOMATIC variable, rewritten by every -match
@@ -316,9 +411,19 @@ function Resolve-WTProfileTarget {
     # The GUID only breaks a tie. If it names a profile whose name is NOT
     # $TargetName, the user asked for a different profile than the one they are
     # sitting in, and that request wins.
-    $entry = $null
-    if ($PreferGuid -and $named.Count -gt 1) {
-        $entry = $named | Where-Object { $_.guid -eq $PreferGuid } | Select-Object -First 1
+    $entry    = $null
+    $tieBreak = $null
+    if ($named.Count -gt 1) {
+        if ($PreferGuid) {
+            $entry = $named | Where-Object { $_.guid -eq $PreferGuid } | Select-Object -First 1
+        }
+        # Recorded HERE, where the choice is actually made. The note the callers
+        # print used to assert "Applied to the one this session is running in"
+        # on every ambiguous resolution -- false whenever $PreferGuid names a
+        # THIRD profile (reset run from an Ubuntu tab, say), which is the
+        # ordinary modern-WT shape. Re-deriving it at the call site would be a
+        # second copy of this decision, so the decision reports itself.
+        $tieBreak = if ($entry) { 'Session' } else { 'First' }
     }
     if (-not $entry) { $entry = $named | Select-Object -First 1 }
 
@@ -326,6 +431,88 @@ function Resolve-WTProfileTarget {
         Ok = [bool]$entry; Entry = $entry; IsDefaults = $false; Available = $available
         # True when the name alone was not enough to identify a profile.
         Ambiguous = ($named.Count -gt 1)
+        # 'Session', 'First', or $null when there was no tie to break.
+        TieBreak  = $tieBreak
+    }
+}
+
+function Get-WTTargetNotFoundMessage {
+    <#
+    .SYNOPSIS
+    The one sentence every caller says when Resolve-WTProfileTarget says no.
+
+    .DESCRIPTION
+    Three callers wrote this message, two of them identically, and all three
+    ended in "Available: " + the list -- which is a dead end when the list is
+    EMPTY. That is not a hypothetical shape: it is exactly the settings.json
+    that used to be accepted for -Target defaults and then cost the user their
+    JSONC comments (no `profiles` key, a null one, a zero-byte file). Refusing
+    it is the fix; refusing it with a sentence that stops mid-air would only
+    move the confusion.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowNull()]$ResolvedTarget,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$TargetName
+    )
+
+    $available = @()
+    if ($ResolvedTarget) { $available = @($ResolvedTarget.Available) }
+    if (-not $available.Count) {
+        # "not an object" rather than "empty": `"profiles": {}` IS usable -- the
+        # defaults block can be created in it -- so this list names only the
+        # shapes that are not.
+        return ("Windows Terminal's settings.json has no profile to apply to: its 'profiles' key is " +
+                "missing, null, or not an object. Check the file, or let Windows Terminal rewrite it.")
+    }
+    return "Windows Terminal profile '$TargetName' not found. Available: $($available -join ', ')"
+}
+
+function Write-AmbiguousTargetNote {
+    <#
+    .SYNOPSIS
+    Say that a -Target name matched more than one profile, and which one won.
+
+    .DESCRIPTION
+    Two Windows Terminal profiles may carry the same `name`, and from outside
+    they are indistinguishable: -Target cannot separate them, so a user cannot
+    check which one a command chose. Resolve-WTProfileTarget breaks the tie with
+    the session's own GUID, which is almost always what was wanted -- and
+    "almost always" is worth one line wherever it is acted on.
+
+    It was acted on in five places and said in one. `tstyles <style>` printed
+    the note; the picker, `tstyles reset`, `tstyles font` and the standalone
+    apply.ps1 resolved the same tie in silence -- and reset is the one that
+    matters most, because it strips every field an apply may write (padding,
+    opacity, useAcrylic, font.face among them) off whichever namesake it picked
+    and then reports "Reset '<name>' to its unstyled default." in green.
+
+    So the note lives here, next to the resolver, and every caller that acts on
+    a resolution reads it. $Verb is the caller's own word for what it did, so
+    the sentence stays true for a reset as well as an apply.
+
+    The second line is NOT unconditional. It claimed the session's profile every
+    time, which is false when the tie could not be broken -- the session is in a
+    third profile, or there is no WT_PROFILE_ID at all -- and that is precisely
+    the sentence a user reads to decide whether the right profile was hit. The
+    resolver records which branch it took; this only reports it.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowNull()]$ResolvedTarget,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$TargetName,
+        # The caller's verb: 'Applied to', 'Reset', 'Applying to'.
+        [string]$Verb = 'Used'
+    )
+
+    if (-not $ResolvedTarget -or -not $ResolvedTarget.Ambiguous) { return }
+
+    Write-Host "  Note: more than one profile is named '$TargetName'." -ForegroundColor DarkGray
+    if ($ResolvedTarget.TieBreak -eq 'Session') {
+        Write-Host ("  {0} the one this session is running in." -f $Verb) -ForegroundColor DarkGray
+    } else {
+        Write-Host ("  {0} the first one in settings.json, guid {1}." -f
+                    $Verb, $ResolvedTarget.Entry.guid) -ForegroundColor DarkGray
     }
 }
 
@@ -410,11 +597,23 @@ function Merge-StyleIntoSettings {
     if (-not (Test-Path -LiteralPath $themePath)) { return $Settings }
     $theme = [System.IO.File]::ReadAllText($themePath, [System.Text.UTF8Encoding]::new($false)) | ConvertFrom-Json
 
+    # The lazy creation, guarded rather than assumed. Add-Member needs a
+    # `profiles` OBJECT to add the block to: on a missing key or a null this
+    # line threw, and on the legacy flat-array form it unrolled the array and
+    # grafted `defaults` onto every profile in it without a word. The resolver
+    # now refuses 'defaults' for both shapes, so a caller that went through it
+    # never arrives here -- this is the same rule stated where the write
+    # happens, for the two callers that merge without resolving first (the
+    # picker's preview and the tuner). Falling through to the existing
+    # `if (-not $entry)` keeps the no-target contract: settings returned
+    # untouched, and no orphan scheme, since the scheme is upserted below.
     $entry = if ($TargetName -eq 'defaults') {
-        if (-not $Settings.profiles.PSObject.Properties.Match('defaults').Count) {
-            $Settings.profiles | Add-Member -NotePropertyName defaults -NotePropertyValue ([pscustomobject]@{})
+        if ((Get-WTProfileShape -Settings $Settings).HasDefaultsSlot) {
+            if (-not $Settings.profiles.PSObject.Properties.Match('defaults').Count) {
+                $Settings.profiles | Add-Member -NotePropertyName defaults -NotePropertyValue ([pscustomobject]@{})
+            }
+            $Settings.profiles.defaults
         }
-        $Settings.profiles.defaults
     } else {
         $namedEntry
     }

--- a/tests/Defaults-Target-ProfilesShape.Tests.ps1
+++ b/tests/Defaults-Target-ProfilesShape.Tests.ps1
@@ -1,0 +1,301 @@
+# Pester 5 tests: 'defaults' is addressable only when settings.json can actually
+# carry a profiles.defaults block.
+#
+# THE BUG. Resolve-WTProfileTarget answered Ok=$true for -Target defaults
+# UNCONDITIONALLY, on the reasoning that an apply creates the block lazily. That
+# lazy creation is `$Settings.profiles | Add-Member`, which needs a profiles
+# OBJECT to add to. Four settings.json shapes have no such object -- no
+# `profiles` key at all, `"profiles": null`, a zero-byte or truncated file (so
+# the parsed settings are $null), and the legacy flat form `"profiles": [ ... ]`
+# -- and on all four the resolver said yes:
+#
+#   * Apply-StyleDirect's -Target guard asks exactly that question, so it
+#     passed, and Save-SettingsBackup spent the rolling .bak -- the user's undo
+#     of their last real apply.
+#   * Merge-StyleIntoSettings then threw "You cannot call a method on a
+#     null-valued expression". A method call on null aborts the STATEMENT, not
+#     the command, and $ErrorActionPreference is 'Continue' in an interactive
+#     shell -- so the assignment never happened, $settings still held the
+#     parsed-but-unmerged object, and the very next line wrote THAT out:
+#     ConvertFrom-WTJson had already stripped the comments, so every // note in
+#     the user's settings.json was deleted, "Style applied" printed in green,
+#     and `tstyles current` named a style no profile had received. Run it a
+#     second time and the .bak -- the one copy that still held the comments --
+#     was overwritten with the stripped file. Unrecoverable from there.
+#   * On the array form there was no throw at all: Add-Member UNROLLS an array,
+#     so every profile in the list gained a `defaults` NoteProperty and the
+#     whole theme was written INSIDE the first profile, where Windows Terminal
+#     ignores it. Silent, and reported as success.
+#
+# This is the same failure the -Target guard was added for in 0.8.17, re-entered
+# through the one target the resolver declared always addressable.
+#
+# Run: Invoke-Pester -Path tests
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+BeforeDiscovery {
+    $repoRoot = Split-Path $PSScriptRoot -Parent
+    Import-Module (Join-Path $repoRoot 'TerminalStyles.psd1') -Force -DisableNameChecking *> $null
+}
+BeforeAll {
+    $repoRoot = Split-Path $PSScriptRoot -Parent
+    Import-Module (Join-Path $repoRoot 'TerminalStyles.psd1') -Force -DisableNameChecking *> $null
+}
+
+Describe "Resolve-WTProfileTarget refuses 'defaults' when there is nothing to create it on" {
+    InModuleScope TerminalStyles {
+        # $null models the zero-byte / whitespace-only / truncated file: on
+        # pwsh 7 ConvertFrom-WTJson returns $null for it, which is what every
+        # reader downstream then holds.
+        It "refuses -Target defaults for <case>" -ForEach @(
+            @{ case = 'a settings.json with no profiles key'; json = '{"schemes":[]}' }
+            @{ case = 'a null profiles key';                  json = '{"profiles":null}' }
+            @{ case = 'an empty object';                      json = '{}' }
+            @{ case = 'the legacy flat-array form';           json = '{"profiles":[{"guid":"{a}","name":"PowerShell"}]}' }
+            @{ case = 'an unparseable/empty settings.json';   json = $null }
+        ) {
+            $settings = if ($json) { $json | ConvertFrom-Json } else { $null }
+            $r = Resolve-WTProfileTarget -Settings $settings -TargetName 'defaults'
+
+            $r.Ok | Should -BeFalse -Because @'
+Ok is what Apply-StyleDirect's guard asks before it spends the rolling backup
+and hands the settings to a merge that cannot write this shape.
+'@
+            $r.Available | Should -Not -Contain 'defaults' `
+                -Because 'offering the one answer guaranteed to be refused is not an error message'
+        }
+
+        It "still calls 'defaults' addressable on an ordinary settings.json" {
+            # The positive control. Without it the guard above could be
+            # satisfied by a resolver that always says no -- and 'defaults' is a
+            # documented, ordinary target (apply.ps1's own header shows it).
+            $s = '{"profiles":{"list":[{"guid":"{a}","name":"PowerShell"}]}}' | ConvertFrom-Json
+            $r = Resolve-WTProfileTarget -Settings $s -TargetName 'defaults'
+            $r.Ok         | Should -BeTrue
+            $r.IsDefaults | Should -BeTrue
+            $r.Entry      | Should -BeNullOrEmpty -Because 'the block is created lazily; Ok without Entry is the point'
+            $r.Available  | Should -Contain 'defaults'
+        }
+
+        It "still calls 'defaults' addressable when the block already exists" {
+            $s = '{"profiles":{"defaults":{"opacity":50},"list":[]}}' | ConvertFrom-Json
+            $r = Resolve-WTProfileTarget -Settings $s -TargetName 'defaults'
+            $r.Ok            | Should -BeTrue
+            $r.Entry.opacity | Should -Be 50
+        }
+
+        It 'names the real profiles of the legacy flat-array form instead of only "defaults"' {
+            # The other half of the same mis-read: Available was built from
+            # $Settings.profiles.list, which is $null for the array form, so a
+            # user with that file was told their only choice was the one target
+            # that would corrupt it.
+            $s = '{"profiles":[{"guid":"{a}","name":"PowerShell"},{"guid":"{b}","name":"Ubuntu"}]}' | ConvertFrom-Json
+            $r = Resolve-WTProfileTarget -Settings $s -TargetName 'PowerShell'
+            $r.Ok         | Should -BeTrue
+            $r.Entry.guid | Should -Be '{a}'
+            $r.Available  | Should -Contain 'Ubuntu'
+        }
+
+        It 'reports no addressable target at all when profiles is missing' {
+            $r = Resolve-WTProfileTarget -Settings ('{"schemes":[]}' | ConvertFrom-Json) -TargetName 'PowerShell'
+            @($r.Available).Count | Should -Be 0
+            # ...and the message must not trail off into an empty list.
+            Get-WTTargetNotFoundMessage -ResolvedTarget $r -TargetName 'PowerShell' |
+                Should -Match "has no profile to apply to"
+        }
+    }
+}
+
+Describe 'Merge-StyleIntoSettings makes the same judgement as the resolver' {
+    InModuleScope TerminalStyles {
+        BeforeEach {
+            # Sandboxed data root AND a mocked background resolver: the merge
+            # resolves a style's background itself, and its third tier
+            # lazy-FETCHES over the network into the cache.
+            $script:savedDataRoot   = $script:TStylesDataRoot
+            $script:TStylesDataRoot = $TestDrive
+            Mock Get-StyleBundledBackground { $null }
+
+            $script:shapeStyle = Join-Path $TestDrive 'styles/shape'
+            New-Item -ItemType Directory -Path $script:shapeStyle -Force | Out-Null
+            [System.IO.File]::WriteAllText((Join-Path $script:shapeStyle 'scheme.json'),
+                '{"name":"shapescheme"}', [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText((Join-Path $script:shapeStyle 'theme.json'),
+                '{"colorScheme":"shapescheme","opacity":90}', [System.Text.UTF8Encoding]::new($false))
+        }
+        AfterEach { $script:TStylesDataRoot = $script:savedDataRoot }
+
+        # The load-bearing agreement: whatever the resolver decides, the merge
+        # must not damage a file it cannot write. Both halves are asserted, so
+        # neither can quietly become vacuous -- the resolver's answer is checked
+        # AND the merge is actually run. On the unfixed code the merge throws
+        # here for the null shapes and silently grafts for the array one.
+        It 'writes nothing for a defaults target on <case>' -ForEach @(
+            @{ case = 'a settings.json with no profiles key'; json = '{"schemes":[]}' }
+            @{ case = 'a null profiles key';                  json = '{"profiles":null}' }
+            @{ case = 'the legacy flat-array form';           json = '{"profiles":[{"guid":"{a}","name":"PowerShell"}]}' }
+        ) {
+            $s = $json | ConvertFrom-Json
+            (Resolve-WTProfileTarget -Settings $s -TargetName 'defaults').Ok | Should -BeFalse
+
+            # Not wrapped in Should -Not -Throw: an exception here fails the It
+            # with the real message, which is the diagnosis.
+            $out = Merge-StyleIntoSettings -Settings $s -StyleDir $script:shapeStyle `
+                -TargetName 'defaults' -BackgroundImage '' -BackgroundImageProvided $false
+
+            @($out.schemes | Where-Object { $_.name -eq 'shapescheme' }).Count | Should -Be 0 `
+                -Because 'a scheme no profile can reference is one Reset can never clean up'
+            # `$null -ne $_` first: piping a scalar $null sends ONE item down
+            # the pipeline, so the member access alone would throw here for the
+            # shapes whose `profiles` is missing entirely.
+            @($out.profiles | Where-Object { $null -ne $_ -and $_.PSObject.Properties.Match('defaults').Count }).Count |
+                Should -Be 0 -Because @'
+Add-Member unrolls an array: the flat-array form grafted a defaults block onto
+every profile in the list and wrote the whole theme where WT ignores it.
+'@
+        }
+
+        It 'still creates and styles profiles.defaults on an ordinary settings.json' {
+            $s = '{"profiles":{"list":[{"guid":"{a}","name":"PowerShell"}]}}' | ConvertFrom-Json
+            $out = Merge-StyleIntoSettings -Settings $s -StyleDir $script:shapeStyle `
+                -TargetName 'defaults' -BackgroundImage '' -BackgroundImageProvided $false
+            $out.profiles.defaults.colorScheme | Should -Be 'shapescheme'
+            $out.profiles.defaults.opacity     | Should -Be 90
+        }
+    }
+}
+
+Describe 'an apply to a settings.json that has no profiles object costs the user nothing' {
+    InModuleScope TerminalStyles {
+        BeforeEach {
+            $script:TStylesModuleRoot = $TestDrive
+            $script:TStylesDataRoot   = $TestDrive
+            $script:TStylesCurrent    = Join-Path $TestDrive 'current-style.ps1'
+
+            $script:shapeStyle = Join-Path $TestDrive 'styles/shape'
+            New-Item -ItemType Directory -Path $script:shapeStyle -Force | Out-Null
+            [System.IO.File]::WriteAllText((Join-Path $script:shapeStyle 'scheme.json'),
+                '{"name":"shapescheme"}', [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText((Join-Path $script:shapeStyle 'theme.json'),
+                '{"colorScheme":"shapescheme","opacity":90}', [System.Text.UTF8Encoding]::new($false))
+
+            # TestDrive is shared across the Its in this file, and the positive
+            # control below legitimately writes a style record. Clear it, or the
+            # "no style was recorded" assertions pass or fail on test ORDER.
+            Remove-Item -LiteralPath (Get-CurrentStyleRecordPath) -Force -ErrorAction SilentlyContinue
+
+            $script:sPath = Join-Path $TestDrive 'settings.json'
+            # A GOOD backup from an earlier, real apply: the thing a command
+            # that cannot do its job must not spend.
+            $script:goodBak = '{"THE-USERS-UNDO":"from their last real apply"}'
+            [System.IO.File]::WriteAllText("$script:sPath.bak", $script:goodBak,
+                [System.Text.UTF8Encoding]::new($false))
+
+            Mock Find-WTSettingsPath          { $script:sPath }
+            Mock Get-TerminalKind             { 'WindowsTerminal' }
+            Mock Show-UpdateNoticeIfAvailable {}
+            Mock Get-StyleBundledBackground   { $null }
+            Mock Write-Host                   {}
+            Mock Write-Error                  {}
+        }
+
+        It 'leaves both files alone and claims nothing: <case>' -ForEach @(
+            @{ case = 'no profiles key'
+               live = @'
+{
+    // I keep my notes in here
+    "defaultProfile": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}",
+    "schemes": []
+}
+'@ }
+            @{ case = 'a null profiles key'
+               live = @'
+{
+    // I keep my notes in here
+    "profiles": null
+}
+'@ }
+            @{ case = 'the legacy flat-array form'
+               live = @'
+{
+    // I keep my notes in here
+    "profiles": [ { "guid": "{a}", "name": "PowerShell" } ]
+}
+'@ }
+        ) {
+            [System.IO.File]::WriteAllText($script:sPath, $live, [System.Text.UTF8Encoding]::new($false))
+
+            Apply-StyleDirect -StyleName 'shape' -Target 'defaults'
+
+            [System.IO.File]::ReadAllText($script:sPath, [System.Text.UTF8Encoding]::new($false)) |
+                Should -Be $live -Because @'
+Write-SettingsFile re-serializes the PARSED object and ConvertFrom-WTJson has
+already dropped every comment, so any write at all deletes the user's own notes.
+'@
+            [System.IO.File]::ReadAllText("$script:sPath.bak", [System.Text.UTF8Encoding]::new($false)) |
+                Should -Be $script:goodBak -Because 'there is one .bak, and it is the undo of the last real apply'
+            Should -Not -Invoke Write-Host -ParameterFilter { "$Object" -match 'Style applied' }
+            Get-CurrentStyleRecord | Should -BeNullOrEmpty `
+                -Because 'tstyles current must not name a style no profile received'
+        }
+
+        It 'leaves both files alone for a zero-byte settings.json' {
+            # Separate from the table because the two engines fail it at
+            # different points and both are correct: pwsh 7's ConvertFrom-Json
+            # returns $null for an empty string and the target guard refuses it,
+            # while Windows PowerShell 5.1 rejects the empty string outright and
+            # ConvertFrom-WTJson's parse error stops the command earlier. What
+            # has to be true on both is that nothing was written -- and it was
+            # not: this shape reached the same crash and then overwrote
+            # settings.json.bak with the empty file while printing "Backed up
+            # settings to: ...".
+            [System.IO.File]::WriteAllText($script:sPath, '', [System.Text.UTF8Encoding]::new($false))
+
+            try { Apply-StyleDirect -StyleName 'shape' -Target 'defaults' } catch { }
+
+            [System.IO.File]::ReadAllText($script:sPath, [System.Text.UTF8Encoding]::new($false)) | Should -Be ''
+            [System.IO.File]::ReadAllText("$script:sPath.bak", [System.Text.UTF8Encoding]::new($false)) |
+                Should -Be $script:goodBak
+            Should -Not -Invoke Write-Host -ParameterFilter { "$Object" -match 'Style applied' }
+        }
+
+        It 'still applies to profiles.defaults on an ordinary settings.json' {
+            # The positive control for the whole Describe: the fix must cost the
+            # documented `-Target defaults` apply nothing.
+            $live = '{ "profiles": { "list": [ { "guid": "{a}", "name": "PowerShell" } ] }, "schemes": [] }'
+            [System.IO.File]::WriteAllText($script:sPath, $live, [System.Text.UTF8Encoding]::new($false))
+
+            Apply-StyleDirect -StyleName 'shape' -Target 'defaults'
+
+            $after = [System.IO.File]::ReadAllText($script:sPath, [System.Text.UTF8Encoding]::new($false)) | ConvertFrom-Json
+            $after.profiles.defaults.colorScheme | Should -Be 'shapescheme'
+            Should -Invoke Write-Host -ParameterFilter { "$Object" -match 'Style applied' }
+            [System.IO.File]::ReadAllText("$script:sPath.bak", [System.Text.UTF8Encoding]::new($false)) |
+                Should -Be $live -Because 'a real apply is exactly when the rolling backup SHOULD be spent'
+        }
+
+        It 'does not write settings.json when the merge fails part-way' {
+            # The amplifier, independent of which target got us there. PowerShell
+            # aborts the failing STATEMENT and carries on, so `$settings =
+            # Merge-...` left $settings holding the parsed-but-unmerged object
+            # and Write-SettingsFile serialized it -- comments gone, "Style
+            # applied" in green. Any future throw inside the merge would do the
+            # same thing again, so the write is guarded rather than the one
+            # throw being fixed.
+            $live = @'
+{
+    // I keep my notes in here
+    "profiles": { "list": [ { "guid": "{a}", "name": "PowerShell" } ] }
+}
+'@
+            [System.IO.File]::WriteAllText($script:sPath, $live, [System.Text.UTF8Encoding]::new($false))
+            Mock Merge-StyleIntoSettings { throw 'the merge could not finish' }
+
+            Apply-StyleDirect -StyleName 'shape' -Target 'PowerShell'
+
+            [System.IO.File]::ReadAllText($script:sPath, [System.Text.UTF8Encoding]::new($false)) | Should -Be $live
+            Should -Not -Invoke Write-Host -ParameterFilter { "$Object" -match 'Style applied' }
+            Get-CurrentStyleRecord | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/Duplicate-ProfileNames.Tests.ps1
+++ b/tests/Duplicate-ProfileNames.Tests.ps1
@@ -52,6 +52,7 @@ Describe 'Resolve-WTProfileTarget breaks a name tie with the session GUID' {
             $r.Entry.guid | Should -Be '{bbbbbbbb-0000-0000-0000-000000000002}' `
                 -Because 'the style belongs in the window the user is looking at'
             $r.Ambiguous | Should -BeTrue
+            $r.TieBreak  | Should -Be 'Session'
         }
 
         It 'still reports the tie when no GUID is available' {
@@ -61,6 +62,23 @@ Describe 'Resolve-WTProfileTarget breaks a name tie with the session GUID' {
             $r.Ok        | Should -BeTrue
             $r.Ambiguous | Should -BeTrue
             $r.Entry.guid | Should -Be '{aaaaaaaa-0000-0000-0000-000000000001}'
+            $r.TieBreak  | Should -Be 'First' -Because 'the caller has to be able to say WHICH, not just that it guessed'
+        }
+
+        It 'reports a first-match tie-break when the session is in a THIRD profile' {
+            # The ordinary modern-WT shape: WT_PROFILE_ID is set and names a
+            # profile that is not either namesake (reset run from the Ubuntu
+            # tab). No tie-break was possible, and the note that claimed the
+            # session's profile was simply false.
+            $r = Resolve-WTProfileTarget -Settings $script:dup -TargetName 'PowerShell' `
+                    -PreferGuid '{cccccccc-0000-0000-0000-000000000003}'
+            $r.Ambiguous | Should -BeTrue
+            $r.TieBreak  | Should -Be 'First'
+        }
+
+        It 'records no tie-break when there was no tie' {
+            $r = Resolve-WTProfileTarget -Settings $script:dup -TargetName 'Ubuntu' -PreferGuid ''
+            $r.TieBreak | Should -BeNullOrEmpty
         }
 
         It 'does NOT let the session GUID override a different -Target' {
@@ -119,6 +137,164 @@ Describe 'an ambiguous profile name is reported, not resolved in silence' {
             Should -Invoke Write-Host -ParameterFilter {
                 "$Object" -match "more than one profile is named"
             } -Because 'a tie the user cannot see must not be broken silently'
+        }
+
+        It 'tells the user when RESET picks between two profiles of the same name' {
+            # The caller that needed it most and never had it. The strip removes
+            # every field an apply may write -- padding, opacity, useAcrylic,
+            # cursorShape, font.face -- from whichever namesake the resolver
+            # chose, and then says "Reset 'PowerShell' to its unstyled default."
+            # in green. Measured on the unfixed code: the first namesake lost
+            # padding "24", opacity 70, useAcrylic and a hand-picked font.face,
+            # with nothing on screen to say a second profile carried that name.
+            $script:TStylesModuleRoot = $TestDrive
+            $script:TStylesDataRoot   = $TestDrive
+            $script:TStylesCurrent    = Join-Path $TestDrive 'current-style3.ps1'
+
+            $styleDir = Join-Path $TestDrive 'styles/amb'
+            New-Item -ItemType Directory -Path $styleDir -Force | Out-Null
+            [System.IO.File]::WriteAllText((Join-Path $styleDir 'scheme.json'), '{"name":"amb"}')
+
+            $sp = Join-Path $TestDrive 'reset-settings.json'
+            [System.IO.File]::WriteAllText($sp, @'
+{ "profiles": { "list": [
+    { "name": "PowerShell", "guid": "{aaaaaaaa-0000-0000-0000-000000000001}", "colorScheme": "amb", "opacity": 70 },
+    { "name": "PowerShell", "guid": "{bbbbbbbb-0000-0000-0000-000000000002}", "colorScheme": "amb", "opacity": 55 }
+] }, "schemes": [ { "name": "amb" } ] }
+'@)
+            Mock Find-WTSettingsPath          { $sp }
+            Mock Get-TerminalKind             { 'WindowsTerminal' }
+            Mock Show-UpdateNoticeIfAvailable {}
+            Mock Write-Host                   {}
+            Mock Write-SettingsFile           { param($Path, $Settings) $script:resetWritten = $Settings }
+
+            $prev = $env:WT_PROFILE_ID
+            try {
+                $env:WT_PROFILE_ID = '{bbbbbbbb-0000-0000-0000-000000000002}'
+                Reset-StyleDirect -Target 'PowerShell'
+            } finally { $env:WT_PROFILE_ID = $prev }
+
+            Should -Invoke Write-Host -ParameterFilter {
+                "$Object" -match 'more than one profile is named'
+            } -Because 'the user cannot tell the two apart, so the choice has to be stated'
+
+            # ...and pin WHICH one was stripped, so the note cannot drift away
+            # from the profile the command actually touched.
+            $chosen   = $script:resetWritten.profiles.list | Where-Object guid -eq '{bbbbbbbb-0000-0000-0000-000000000002}'
+            $untouched = $script:resetWritten.profiles.list | Where-Object guid -eq '{aaaaaaaa-0000-0000-0000-000000000001}'
+            $chosen.PSObject.Properties.Match('opacity').Count    | Should -Be 0
+            $untouched.opacity                                    | Should -Be 70
+        }
+
+        It 'tells the user when FONT picks between two profiles of the same name' {
+            $script:TStylesModuleRoot = $TestDrive
+            $script:TStylesDataRoot   = $TestDrive
+
+            $sp = Join-Path $TestDrive 'font-settings.json'
+            [System.IO.File]::WriteAllText($sp, @'
+{ "profiles": { "list": [
+    { "name": "PowerShell", "guid": "{aaaaaaaa-0000-0000-0000-000000000001}" },
+    { "name": "PowerShell", "guid": "{bbbbbbbb-0000-0000-0000-000000000002}" }
+] }, "schemes": [] }
+'@)
+            Mock Find-WTSettingsPath    { $sp }
+            Mock Get-TerminalKind       { 'WindowsTerminal' }
+            Mock Get-TerminalCapability { [pscustomobject]@{ Font = $true } }
+            Mock Get-FontCatalog        { @([pscustomobject]@{ name='jb'; family='JetBrains Mono'; license='OFL'; url='x'; sha256='y' }) }
+            Mock Test-FontInstalled     { $true }
+            Mock Write-Host             {}
+
+            Invoke-TerminalStyleFont -Name 'jb' -Target 'PowerShell'
+
+            Should -Invoke Write-Host -ParameterFilter {
+                "$Object" -match 'more than one profile is named'
+            } -Because '"Applied <font> to PowerShell" is two different claims when two profiles carry the name'
+        }
+
+        It 'tells the user when the PICKER picks between two profiles of the same name' {
+            # The sharpest asymmetry of the five: `tstyles <style>` printed the
+            # note, `tstyles` -- the picker, same resolver, same write -- printed
+            # nothing. Driven the way tests/Apply-StyleDirect-TargetValidation
+            # drives it: the target is validated before the picker's
+            # interactive-console guard, so the call returns without reaching
+            # the keyboard loop.
+            $script:TStylesModuleRoot = $TestDrive
+            $script:TStylesDataRoot   = $TestDrive
+
+            $styleDir = Join-Path $TestDrive 'styles/amb4'
+            New-Item -ItemType Directory -Path $styleDir -Force | Out-Null
+            [System.IO.File]::WriteAllText((Join-Path $styleDir 'scheme.json'), '{"name":"amb4"}')
+            [System.IO.File]::WriteAllText((Join-Path $styleDir 'theme.json'), '{"colorScheme":"amb4"}')
+
+            $sp = Join-Path $TestDrive 'picker-settings.json'
+            [System.IO.File]::WriteAllText($sp, @'
+{ "profiles": { "list": [
+    { "name": "PowerShell", "guid": "{aaaaaaaa-0000-0000-0000-000000000001}" },
+    { "name": "PowerShell", "guid": "{bbbbbbbb-0000-0000-0000-000000000002}" }
+] }, "schemes": [] }
+'@)
+            Mock Find-WTSettingsPath       { $sp }
+            Mock Get-TerminalKind          { 'WindowsTerminal' }
+            Mock Invoke-FontFirstRunPrompt {}
+            Mock Test-UpdateAvailable      { $null }
+            Mock Write-Host                {}
+            Mock Write-Error               {}
+
+            if (-not ([Console]::IsInputRedirected -or [Console]::IsOutputRedirected)) {
+                Set-ItResult -Skipped -Because 'a real console is attached; the picker would take it over'
+                return
+            }
+
+            Invoke-TerminalStyle -Target 'PowerShell'
+
+            Should -Invoke Write-Host -ParameterFilter {
+                "$Object" -match 'more than one profile is named'
+            }
+        }
+
+        It 'does not claim the session profile when the session is in neither of them' {
+            # The note's second line was unconditional, so it asserted "Applied
+            # to the one this session is running in." even when WT_PROFILE_ID
+            # named a third profile and the resolver had fallen back to file
+            # order. That sentence is the one a user reads to decide whether the
+            # right profile was hit.
+            $script:TStylesModuleRoot = $TestDrive
+            $script:TStylesDataRoot   = $TestDrive
+            $script:TStylesCurrent    = Join-Path $TestDrive 'current-style5.ps1'
+
+            $styleDir = Join-Path $TestDrive 'styles/amb5'
+            New-Item -ItemType Directory -Path $styleDir -Force | Out-Null
+            [System.IO.File]::WriteAllText((Join-Path $styleDir 'scheme.json'), '{"name":"amb5"}')
+            [System.IO.File]::WriteAllText((Join-Path $styleDir 'theme.json'), '{"colorScheme":"amb5"}')
+
+            $sp = Join-Path $TestDrive 'third-settings.json'
+            [System.IO.File]::WriteAllText($sp, @'
+{ "profiles": { "list": [
+    { "name": "PowerShell", "guid": "{aaaaaaaa-0000-0000-0000-000000000001}" },
+    { "name": "PowerShell", "guid": "{bbbbbbbb-0000-0000-0000-000000000002}" },
+    { "name": "Ubuntu",     "guid": "{cccccccc-0000-0000-0000-000000000003}" }
+] }, "schemes": [] }
+'@)
+            Mock Find-WTSettingsPath        { $sp }
+            Mock Get-TerminalKind           { 'WindowsTerminal' }
+            Mock Get-StyleBundledBackground { $null }
+            Mock Write-Host                 {}
+
+            $prev = $env:WT_PROFILE_ID
+            try {
+                $env:WT_PROFILE_ID = '{cccccccc-0000-0000-0000-000000000003}'
+                Apply-StyleDirect -StyleName 'amb5' -Target 'PowerShell'
+            } finally { $env:WT_PROFILE_ID = $prev }
+
+            Should -Invoke Write-Host -ParameterFilter {
+                "$Object" -match 'more than one profile is named'
+            }
+            Should -Not -Invoke Write-Host -ParameterFilter {
+                "$Object" -match 'this session is running in'
+            } -Because 'the session is in Ubuntu; nothing broke the tie'
+            Should -Invoke Write-Host -ParameterFilter {
+                "$Object" -match 'the first one in settings.json'
+            }
         }
 
         It 'says nothing for an ordinary unique name' {

--- a/tstyles.ps1
+++ b/tstyles.ps1
@@ -745,9 +745,16 @@ function Invoke-TerminalStyle {
     $validateTarget = {
         param([string]$Name)
         $resolved = Resolve-WTProfileTarget -Settings $originalSettings -TargetName $Name
-        if ($resolved.Ok) { return $true }
-        Write-Error ("Windows Terminal profile '$Name' not found. Available: " +
-                     ($resolved.Available -join ', '))
+        if ($resolved.Ok) {
+            # Said here, at validation, because it is the last moment the user
+            # can read anything: the picker takes the screen on the next frame
+            # and clears it again on confirm. The picker writes the style to the
+            # resolved profile exactly as `tstyles <style>` does, and was the
+            # only one of the pair that never mentioned the tie.
+            Write-AmbiguousTargetNote -ResolvedTarget $resolved -TargetName $Name -Verb 'Applying to'
+            return $true
+        }
+        Write-Error (Get-WTTargetNotFoundMessage -ResolvedTarget $resolved -TargetName $Name)
         return $false
     }
 
@@ -830,7 +837,11 @@ function Invoke-TerminalStyle {
     # replace with an explanation.
     if ($useSettingsFile -and -not $Target) {
         Write-Host "Could not auto-detect the current Windows Terminal profile."
-        Write-Host "Available: $((@('defaults') + @($originalSettings.profiles.list.name)) -join ', ')"
+        # The same list the validator below will accept, from the same place.
+        # Built here by hand, it offered 'defaults' for a settings.json that
+        # cannot carry one -- a prompt naming the single answer guaranteed to be
+        # refused.
+        Write-Host "Available: $((Get-WTProfileShape -Settings $originalSettings).Available -join ', ')"
         $Target = (Read-Host "Target profile").Trim()
         if (-not $Target) { return }
         # The answer is a name the user typed, so it gets the same check.


### PR DESCRIPTION
From the backlog gate (findings 6 and 5 — same resolver, one job). The gate found #6 **worse** than the lead claimed.

## The defect

`Resolve-WTProfileTarget` returned `Ok = $true` for `defaults` **unconditionally**, reasoning that the block need not exist yet because an apply creates it lazily. It creates it with `$Settings.profiles | Add-Member` — which has nothing to add to unless `profiles` is a JSON object. A hand-minimised `settings.json` may have no `profiles` key; `"profiles": null` parses to nothing; a truncated write leaves a zero-byte file.

So `Apply-StyleDirect`'s guard passed, the rolling `.bak` was spent, and the merge threw *"You cannot call a method on a null-valued expression"*.

**A method call on `$null` aborts the statement, not the script**, and `$ErrorActionPreference` is `Continue` interactively — so `$settings` kept the parsed-but-unmerged object and the very next line wrote it out. Comments gone, style in no profile, `tstyles current` naming it anyway.

That is precisely the failure the `-Target` guard was added to prevent — *"a misspelled profile name silently and irreversibly deleted their JSONC comments"* — re-entered through the one target the resolver declared always addressable.

Three amplifiers the gate established:

- **Unrecoverable on the second run.** Run 1 leaves the good file in `.bak`; run 2 copies the stripped one over it.
- **A zero-byte `settings.json`** makes the backup overwrite the `.bak` with the empty file, while printing "Backed up settings to: …".
- **The legacy `"profiles": [ ... ]` form never throws at all.** `Add-Member` *unrolls* an array, grafting `defaults` onto every profile object — the whole theme written where Windows Terminal ignores it — while the resolver advertised "Available: defaults" and named none of the user's real profiles.

## Measured, both ways

```
shape              main                              fixed
no profiles key    throws -> comments deleted        returns, writes nothing
legacy array       grafts defaults onto a profile    does not
```

And the resolver across six shapes with the fix:

```
settings.json shape   defaults?  Available
normal                True       defaults, PowerShell
no profiles key       False      (none)
profiles: null        False      (none)
profiles: {}          True       defaults        <- an object CAN take the member
legacy array          False      PowerShell      <- real profiles named at last
empty file            False      (none)
```

## The fix

`Get-WTProfileShape` answers "what is `profiles`, and what may a target name" **once**, and the four readers that each assumed the modern shape consult it: the resolver for `Ok`/`Available`, `Merge-StyleIntoSettings` and `Set-ProfileFont` for their lazy creation, reset's orphan-scheme sweep for enumeration. A resolver-only fix would have left the crash reachable from the picker preview and the tuner, which merge without consulting `Ok`.

The slot test is **structural** ("something a member can be hung on") rather than a type name — the implementer found the suggested `-is [pscustomobject]` tests the `PSObject` accelerator, which the parsed object is not, and would have answered differently across engines.

Making array-form profiles reachable meant fixing reset's `stillUsed` computation in the same change: profiles it previously could not see would otherwise have let a reset delete a scheme still in use. That is the check-the-other-half rule.

`Apply-StyleDirect` also no longer writes when the merge did not come back — six lines that separate an ugly error from silent comment loss, and that will do the same for the next throw inside the merge.

## Finding 5, folded in

`Ambiguous` had two producers and exactly one consumer across **eleven** call sites, so only `tstyles <style>` warned about a duplicated profile name — the picker, reset, font, tune and `apply.ps1` all resolved one silently. One shared note now, read by all five. The resolver also records *how* it broke the tie, so the note no longer claims "the one this session is running in" when `WT_PROFILE_ID` names a third profile and file order actually decided.

A source-shape lint for this was deliberately **not** added: three callers legitimately resolve without notifying, so it would need three exemptions — and CLAUDE.md lists source-text assertions as a way tests pass while measuring nothing.

## Verification

Binding: 15 of 19 fail in the new shape tests against reverted source, 7 of 14 in the duplicate-name tests. The four that pass either way are positive controls, so the guard cannot be satisfied by always saying no.

The two tables above are my own runs against both trees. Full suite: 1679 passed, 11 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4UptB5S567PxKmMdyH8T1
