### PR TITLE
ci(drift): the version comparison threw on anything it could not parse

### DIFF
--- a/.github/workflows/release-drift.yml
+++ b/.github/workflows/release-drift.yml
@@ -40,8 +40,15 @@ jobs:
       - name: Compare the newest tag with what PSGallery serves
         shell: pwsh
         run: |
-          $tag = (git tag -l --sort=-v:refname | Select-Object -First 1)
-          if (-not $tag) { Write-Host "No tags yet; nothing to compare."; exit 0 }
+          # Only tags shaped vN.N[.N[.N]] are candidates, and the newest is
+          # taken from THAT list. `--sort=-v:refname` alone sorts whatever is
+          # there, so one tag that is not a version -- a marker on the gifs
+          # branch, a `latest`, anything a human adds -- could come out on top
+          # and be compared as if it were a release.
+          $tag = @(git tag -l 'v*' --sort=-v:refname |
+                     Where-Object { $_ -match '^v\d+(\.\d+){1,3}$' }) |
+                   Select-Object -First 1
+          if (-not $tag) { Write-Host "No version tags yet; nothing to compare."; exit 0 }
           $tagVersion = $tag -replace '^v', ''
 
           # Read-only, unauthenticated, and allowed to fail: PSGallery being
@@ -57,7 +64,21 @@ jobs:
           Write-Host "newest tag : $tagVersion"
           Write-Host "PSGallery  : $published"
 
-          if ([version]$published -ge [version]$tagVersion) {
+          # TryParse, not a [version] cast. A cast THROWS on anything it cannot
+          # read -- a prerelease suffix like 0.9.0-beta1, or a version string
+          # PSGallery formats unexpectedly -- and these two lines sit outside
+          # the try/catch above, so the throw would fail this job with
+          # "Cannot convert value ..." every Monday. That reads like drift and
+          # is not: it is this check being unable to answer, which is a warning.
+          $pv = $null; $tv = $null
+          if (-not [version]::TryParse($published, [ref]$pv) -or
+              -not [version]::TryParse($tagVersion, [ref]$tv)) {
+              Write-Host "::warning::Could not compare '$published' with '$tagVersion' as versions."
+              Write-Host "Not treating this as drift."
+              exit 0
+          }
+
+          if ($pv -ge $tv) {
               Write-Host "PSGallery is up to date."
               exit 0
           }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
         shell: powershell
         run: |
           # Windows PowerShell 5.1 ships Pester 3 in-box and lacks PSResourceGet,
-          # so bootstrap Pester 5 via PowerShellGet v2. Force TLS 1.2 first: on
+          # so bootstrap Pester via PowerShellGet v2. Force TLS 1.2 first: on
           # .NET Framework the default SecurityProtocol can omit it, and PSGallery
           # hard-refuses TLS < 1.2.
           [Net.ServicePointManager]::SecurityProtocol = `
@@ -83,8 +83,10 @@ jobs:
         if: matrix.shell == 'pwsh'
         shell: pwsh
         run: |
-          # Pin to Pester 5 explicitly so WinPS 5.1 doesn't auto-load its in-box
-          # Pester 3 (which lacks New-PesterConfiguration).
+          # A FLOOR, not a pin: it stops Windows PowerShell 5.1 auto-loading its
+          # in-box Pester 3 (which has no New-PesterConfiguration), and takes
+          # the newest installed above that -- which the install step has now
+          # bounded below 7.0.0, so this cannot reach a major nobody chose.
           Import-Module Pester -MinimumVersion 5.0.0
           $config = New-PesterConfiguration
           $config.Run.Path = 'tests'


### PR DESCRIPTION
Follow-up to #38, found by reading the workflow rather than waiting for it to break.

## The defect

`release-drift.yml` compares the newest tag with PSGallery's version using `[version]` casts — and **both sit outside the try/catch** that guards the PSGallery query:

```
[version] '0.8.25'       -> ok
[version] '0.9.0-beta1'  -> THROWS
[version] 'gifs-base'    -> THROWS
```

All 41 tags in this repo are `vN.N.N` today, so it works. But one prerelease tag, or any tag a human adds that is not a version, and this job goes red **every Monday** with `Cannot convert value ...` — an error that reads like drift and is not.

That is the worst possible failure for this particular check, whose entire value is being believed when it says a release did not ship. A check that cries wolf gets muted, and then the next real unpublished release goes unnoticed — which is the exact thing it was written to prevent.

The tag selection had the same shape of problem: `git tag -l --sort=-v:refname | Select-Object -First 1` sorts whatever is there, so a non-version tag could come out on top and be compared as if it were a release.

## The fix

Candidate tags must match `^v\d+(\.\d+){1,3}$`. Both versions go through `TryParse` instead of a cast. Unparseable is a **warning and exit 0** — this check being unable to answer is not a release problem, the same reasoning already applied to an unreachable PSGallery.

## Verified against every shape

```
normal          : up to date -> exit 0
behind          : DRIFT 0.8.21 < 0.8.25 -> exit 1
junk tag on top : up to date -> exit 0        (skips the junk, uses v0.8.25)
prerelease tag  : up to date -> exit 0        (skips it, uses v0.8.25)
odd gallery ver : unparseable -> warning, exit 0
no tags at all  : no version tags -> exit 0
```

No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4UptB5S567PxKmMdyH8T1