### PR TITLE
fix(shell): five places on the loader paths reported success for something that had not happened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **five places on the shell and loader paths reported success for something that had not happened.** They are one defect wearing five hats: a function that knows why it failed hands its caller a value that cannot carry the reason. This file already had the answer -- `Unregister-ShellLoader` returns `removed` / `none` / `malformed` / `failed` and its callers compare explicitly -- and the other four places on the same paths had each collapsed a status to a boolean or to nothing.
+
+  `Register-ShellLoader` reported `updated` for an rc file carrying a BEGIN with no matching END: it wrote the file back byte-for-byte and told the user it had installed the loader. Its sibling has returned `malformed` for exactly that input since 0.8.22, so the two halves of the same marker rule disagreed. Measured on the same file: `Register` said `updated` where `Unregister` said `malformed`.
+
+  `tstyles uninstall` swept the rc files with `if ((Unregister-ShellLoader ...) -eq 'removed')`, discarding the other three answers, so a file it had just promised to strip could be left carrying the block with nothing said and "TerminalStyles uninstalled." printed underneath. `shell-remove` reported all four. The sweep-and-report rule is now one function both call, since that duplication is what let the two drift.
+
+  `tstyles register` wrote both `$PROFILE` files in an unguarded loop, so the second one failing left the command half-applied under a promise that every new tab would auto-load. Each target is now guarded: on failure it removes the first-touch backup it took of a file it never modified, names the path and the reason, and the auto-load line prints only if at least one target really got the block.
+
+  `Set-ShellStyleState` swallowed every failure in the zsh/bash half of an apply in one `catch { }`, so `tstyles <style>` reported success while new tabs kept the previous prompt. `Sync-ShellRuntime` returned one boolean for two unrelated causes, so `shell-init` blamed a missing module file whatever had actually gone wrong -- including a data root that refused the write.
+
+  A status names the category, which is what a caller branches on, and cannot also carry "access is denied" versus "no space left on the device", which is the half the user acts on. Both staging functions now set one documented module-scoped variable on the way out, read only alongside a non-`ok` status.
+
+  Found while reproducing the above: `Unregister-ShellLoader`'s READ was outside its try, so an unreadable rc file threw a raw `MethodInvocationException` out of the middle of both callers rather than returning `failed`.
+
 ## [0.8.25] - 2026-09-12
 
 ### Fixed

--- a/lib/applystyle.ps1
+++ b/lib/applystyle.ps1
@@ -487,7 +487,12 @@ function Apply-StyleNonWT {
     # Stage the zsh/bash side too. The user's login shell is probably not
     # PowerShell, and the colors belong to the terminal rather than to any one
     # shell -- so a zsh tab opened after this should come up styled as well.
-    Set-ShellStyleState -StyleName $StyleName -StyleDir $StyleDir -Scheme $scheme -KeepPrompt:$KeepPrompt
+    #
+    # The status is captured because it is reported below. Staging is
+    # best-effort by design, but it decides what every FUTURE tab looks like,
+    # and a silent failure left them all on the previous style while this
+    # function printed "Style applied".
+    $staged = Set-ShellStyleState -StyleName $StyleName -StyleDir $StyleDir -Scheme $scheme -KeepPrompt:$KeepPrompt
 
     # Prompt/banner: same contract as the Windows Terminal path.
     $styleProfile = Join-Path $StyleDir 'profile.ps1'
@@ -503,17 +508,27 @@ function Apply-StyleNonWT {
     Write-Host "  Terminal:      " -NoNewline
     Write-Host (Get-TerminalDisplayName -Kind $kind) -ForegroundColor Cyan
 
+    # The same treatment the OSC half below has always had, for the half that
+    # decides every tab AFTER this one. Through the shared notice, so the picker
+    # cannot end up saying something different about the same failure.
+    Show-ShellStagingFailure -Status $staged
+
     if (-not $applied) {
         Write-Host ""
         if ([Console]::IsOutputRedirected) {
-            # The style IS recorded and staged -- a new tab will come up in it.
-            # What could not happen is repainting THIS session, because its
-            # output does not go to a terminal. Say that precisely: the
-            # alternative is a user watching an unchanged window after being
-            # told the style was applied.
+            # The style IS recorded, and staged when the staging worked -- a new
+            # tab will come up in it. What could not happen is repainting THIS
+            # session, because its output does not go to a terminal. Say that
+            # precisely: the alternative is a user watching an unchanged window
+            # after being told the style was applied.
             Write-Host "  Colors were not applied to this session: its output is redirected," -ForegroundColor Yellow
-            Write-Host "  so there is no terminal to repaint. The style is saved -- open a new" -ForegroundColor Yellow
-            Write-Host "  tab, or run tstyles directly in your terminal, to see it." -ForegroundColor Yellow
+            Write-Host "  so there is no terminal to repaint." -ForegroundColor Yellow
+            if ($staged -eq 'ok') {
+                # Conditional, because this is the sentence a staging failure
+                # falsifies word for word.
+                Write-Host "  The style is saved -- open a new tab, or run tstyles directly in your" -ForegroundColor Yellow
+                Write-Host "  terminal, to see it." -ForegroundColor Yellow
+            }
         } else {
             Write-Host "  Note: this terminal did not accept live color changes, so only the prompt was applied." -ForegroundColor Yellow
         }

--- a/lib/update.ps1
+++ b/lib/update.ps1
@@ -315,36 +315,70 @@ $loaderEnd
         return
     }
 
-    # Write the block per target (strip first for -Force path)
+    # Write the block per target (strip first for -Force path).
+    #
+    # Guarded, with a per-target status, which is the contract Register-ShellLoader
+    # documents for the rc half of the same job -- "'failed' rather than an
+    # exception ... so the user saw a stack trace and had no idea which of their
+    # rc files had been touched". This half had none of it: the read and the
+    # write were bare, and "Registered in <path>" printed unconditionally on the
+    # line after. An unwritable $PROFILE (read-only bit, root-owned, a OneDrive
+    # lock or a Files-On-Demand placeholder) therefore produced a red .NET error
+    # AND a green success line for the same file, and the command still closed
+    # on "TerminalStyles will auto-load on every new shell tab."
+    $failed = @()
     foreach ($t in $toWrite) {
-        $profileDir = Split-Path -Parent $t.ProfilePath
-        if ($profileDir -and -not (Test-Path -LiteralPath $profileDir)) {
-            New-Item -ItemType Directory -Path $profileDir -Force | Out-Null
+        $bak = $null
+        try {
+            $profileDir = Split-Path -Parent $t.ProfilePath
+            if ($profileDir -and -not (Test-Path -LiteralPath $profileDir)) {
+                New-Item -ItemType Directory -Path $profileDir -Force -ErrorAction Stop | Out-Null
+            }
+
+            $existing = if ($t.Exists) {
+                [System.IO.File]::ReadAllText($t.ProfilePath, (Get-RcFileEncoding))
+            } else { '' }
+
+            if ($existing -match $blockPattern) {
+                $existing = [regex]::Replace($existing, $blockPattern, '')
+            }
+
+            $final = ($existing.TrimEnd() + "`r`n`r`n" + $loaderBody + "`r`n").TrimStart()
+            # Same first-touch rule the bootstrap installer has always applied to
+            # $PROFILE. The module half never did, so `tstyles register` rewrote a
+            # hand-maintained profile with no copy kept.
+            $bak = Save-FirstTouchBackup -Path $t.ProfilePath -Content $existing -BlockPattern ([regex]::Escape($loaderBegin))
+            [System.IO.File]::WriteAllText($t.ProfilePath, $final, (Get-RcFileEncoding))
+        } catch {
+            # The backup was taken of a file we then never modified, and the
+            # block never landed -- so the next run took another one, and the
+            # one after that. Announced only after the write, for the same
+            # reason: a backup line for an unchanged file reads as success.
+            if ($bak) { Remove-Item -LiteralPath $bak -Force -ErrorAction SilentlyContinue }
+            $failed += $t
+            Write-Host "  ! could not write $($t.ProfilePath)" -ForegroundColor Red
+            Write-Host "    $($_.Exception.Message)" -ForegroundColor Red
+            Write-Host "    Check the file's permissions (a read-only profile, one managed by nix" -ForegroundColor Red
+            Write-Host "    or chezmoi, or a cloud-synced placeholder) and run this again." -ForegroundColor Red
+            continue
         }
 
-        $existing = if ($t.Exists) {
-            [System.IO.File]::ReadAllText($t.ProfilePath, (Get-RcFileEncoding))
-        } else { '' }
-
-        if ($existing -match $blockPattern) {
-            $existing = [regex]::Replace($existing, $blockPattern, '')
-        }
-
-        $final = ($existing.TrimEnd() + "`r`n`r`n" + $loaderBody + "`r`n").TrimStart()
-        # Same first-touch rule the bootstrap installer has always applied to
-        # $PROFILE. The module half never did, so `tstyles register` rewrote a
-        # hand-maintained profile with no copy kept.
-        $bak = Save-FirstTouchBackup -Path $t.ProfilePath -Content $existing -BlockPattern ([regex]::Escape($loaderBegin))
         if ($bak) { Write-Host "  Backed up your existing $($t.Label) profile to: $bak" -ForegroundColor Gray }
-        [System.IO.File]::WriteAllText($t.ProfilePath, $final, (Get-RcFileEncoding))
-
         Write-Host "  Registered in $($t.ProfilePath)" -ForegroundColor Green
     }
 
     Write-Host ""
-    Write-Host "TerminalStyles will auto-load on every new shell tab." -ForegroundColor Cyan
-    Write-Host "To verify in this session: Import-Module TerminalStyles -Force -DisableNameChecking" -ForegroundColor Gray
-    Write-Host ""
+    if ($failed.Count -gt 0) {
+        Write-Host ("Not registered in: {0}" -f (($failed | ForEach-Object { $_.Label }) -join ', ')) -ForegroundColor Red
+        Write-Host ""
+    }
+    # Only when something really was written. The promise is about what a new
+    # tab will load, and nothing loads out of a file the block never reached.
+    if ($failed.Count -lt @($toWrite).Count) {
+        Write-Host "TerminalStyles will auto-load on every new shell tab." -ForegroundColor Cyan
+        Write-Host "To verify in this session: Import-Module TerminalStyles -Force -DisableNameChecking" -ForegroundColor Gray
+        Write-Host ""
+    }
 }
 
 
@@ -667,17 +701,19 @@ function Invoke-TerminalStylesUninstall {
     # exact path baked into the generated tstyles-cli.ps1, so the shell's own
     # `tstyles` command could no longer load the module. That left hand-editing
     # ~/.zshrc as the only recovery.
-    $shellRemoved = 0
     # The removal superset, not the registration list: shell-init can register
     # into ~/.profile, and sweeping the narrow list orphaned that block forever.
-    foreach ($c in (Get-ShellRcRemovalCandidate @rcSplat)) {
-        # Explicit comparison: Unregister-ShellLoader returns a STATUS now, and
-        # every status -- including 'none' -- is a truthy string.
-        if ((Unregister-ShellLoader -Path $c.Path) -eq 'removed') {
-            Write-Host "  Removed shell loader from $($c.Path)" -ForegroundColor Green
-            $shellRemoved++
-        }
-    }
+    #
+    # Through the same helper `tstyles shell-remove` uses. This loop used to be
+    # its own copy of the rule, comparing the four-state status against exactly
+    # one value -- an explicit comparison, so the lint for "don't use the status
+    # as a boolean" passed, while 'failed' and 'malformed' were thrown away in
+    # silence. The consent screen above NAMES these files one per line, and two
+    # of them could be left carrying the block with nothing said about it.
+    $sweep = Remove-ShellLoaderBlock -Path @(Get-ShellRcRemovalCandidate @rcSplat |
+                                             ForEach-Object { $_.Path })
+    $shellRemoved  = $sweep.Removed
+    $shellProblems = $sweep.Problems
     Clear-ShellStyleState
 
     # The generated WezTerm module. Removal is a single delete because nothing
@@ -717,7 +753,28 @@ function Invoke-TerminalStylesUninstall {
     }
 
     Write-Host ""
-    Write-Host "TerminalStyles uninstalled." -ForegroundColor Cyan
+    # The last line the user reads, and it was printed unconditionally. An rc
+    # file this command could not strip is one the user now has to find and edit
+    # by hand: step 1 has removed the module, so `tstyles shell-remove` -- the
+    # documented way out -- cannot run any more.
+    if ($shellProblems.Count -gt 0) {
+        Write-Host "TerminalStyles uninstalled, EXCEPT the loader block in:" -ForegroundColor Yellow
+        foreach ($p in $shellProblems) {
+            Write-Host ("  {0}" -f $p) -ForegroundColor Yellow
+        }
+        # Single-quoted: a backtick opens an escape in a double-quoted string,
+        # and `t is a tab.
+        Write-Host 'Delete those blocks by hand -- the module is gone, so `tstyles shell-remove`' -ForegroundColor Yellow
+        # What is safe to promise about the leftovers, and no more: the staged
+        # style state has just been cleared, so whatever the block still finds
+        # to source has nothing left to paint. Whether the runtime file itself
+        # survives depends on the install kind, and this is not the line to
+        # explain that in.
+        Write-Host "cannot do it for you now. Until you do, they paint nothing: the staged style" -ForegroundColor Gray
+        Write-Host "state is gone, so there is nothing left for them to apply." -ForegroundColor Gray
+    } else {
+        Write-Host "TerminalStyles uninstalled." -ForegroundColor Cyan
+    }
     Write-Host "Open a new pwsh tab to confirm the loader is gone." -ForegroundColor Gray
     Write-Host "Your settings.json was NOT modified. If you want a default look back," -ForegroundColor Gray
     Write-Host "restore a settings.json.bak-* backup or edit it via WT Settings -> Open JSON file." -ForegroundColor Gray

--- a/terminals.ps1
+++ b/terminals.ps1
@@ -427,14 +427,41 @@ function Get-ShellOscPath    { Join-Path $script:TStylesDataRoot 'current-style.
 
 function Get-ShellCliPath { Join-Path $script:TStylesDataRoot 'tstyles-cli.ps1' }
 
+# WHY the last staging step failed, in the OS's own words.
+#
+# A status names the CATEGORY of failure, which is what the caller branches on,
+# and it cannot also carry the reason -- but the reason is the actionable half:
+# "access is denied" and "no space left on the device" send the user to two
+# different places. Set by the function that returns the non-'ok' status, and
+# valid only for the caller that just received one.
+$script:TStylesShellStagingError = $null
+
 function Sync-ShellRuntime {
     # Refresh the staged runtime from the module. Runs on every apply so an
     # upgraded module's runtime replaces the staged copy without the user having
     # to re-run shell-init.
+    #
+    # Returns a STATUS, not a boolean:
+    #   'ok'       -- tstyles.sh and the generated shim are staged and current
+    #   'nosource' -- shell/tstyles.sh is not in the module: a broken install
+    #   'failed'   -- the data root would not take the write; the reason is in
+    #                 $script:TStylesShellStagingError
+    #
+    # The last two are two unrelated things that used to be one $false, and the
+    # caller printed the FIRST cause for both. So a user whose data root was
+    # read-only, root-owned after a sudo install, or simply full was told
+    # "shell/tstyles.sh missing from the module" -- which sends them to reinstall
+    # the module, the one action that cannot help -- while the directory really
+    # at fault was never named. Same rule as Unregister-ShellLoader's four
+    # statuses, and the same reason.
+    $script:TStylesShellStagingError = $null
     $src = Join-Path (Join-Path $script:TStylesModuleRoot 'shell') 'tstyles.sh'
-    if (-not (Test-Path -LiteralPath $src)) { return $false }
+    if (-not (Test-Path -LiteralPath $src)) { return 'nosource' }
     try {
-        Copy-Item -LiteralPath $src -Destination (Get-ShellRuntimePath) -Force
+        # -ErrorAction Stop because Copy-Item ALSO writes the failure to the
+        # error stream: without it a red "Access to the path ... is denied"
+        # printed immediately above the message that contradicted it.
+        Copy-Item -LiteralPath $src -Destination (Get-ShellRuntimePath) -Force -ErrorAction Stop
 
         # Entry point for the `tstyles` shell function. Generated rather than
         # shipped because a BOOTSTRAP install is not on $env:PSModulePath, so
@@ -486,9 +513,10 @@ $importLine
 Invoke-TerminalStyle @args
 "@
         [System.IO.File]::WriteAllText((Get-ShellCliPath), $cli, [System.Text.UTF8Encoding]::new($false))
-        return $true
+        return 'ok'
     } catch {
-        return $false
+        $script:TStylesShellStagingError = $_.Exception.Message
+        return 'failed'
     }
 }
 
@@ -500,12 +528,26 @@ function Set-ShellStyleState {
     #
     # Best-effort throughout: a PowerShell user with no shell integration set up
     # should never see an apply fail because these could not be written.
+    #
+    # Best effort still has to REPORT, so it returns 'ok' or 'failed' (with the
+    # reason in $script:TStylesShellStagingError) rather than nothing. The catch
+    # below used to be `} catch { }`, and these two files are what every FUTURE
+    # zsh/bash tab reads: one failed write left them on the PREVIOUS style while
+    # the apply printed its ordinary green success block and told the user the
+    # style was saved for the next tab. The half that repaints THIS tab has
+    # always reported its own failure precisely; this is the half that decides
+    # every tab after it.
+    #
+    # Both call sites must CONSUME the status -- a bare statement would emit it
+    # into `tstyles`' own output. tests/Picker-ShellStateStaging.Tests.ps1 walks
+    # the AST for that.
     param(
         [Parameter(Mandatory)][string]$StyleName,
         [Parameter(Mandatory)][string]$StyleDir,
         [Parameter(Mandatory)]$Scheme,
         [switch]$KeepPrompt
     )
+    $script:TStylesShellStagingError = $null
     try {
         $enc = [System.Text.UTF8Encoding]::new($false)
         [System.IO.File]::WriteAllText((Get-ShellOscPath),
@@ -521,8 +563,34 @@ function Set-ShellStyleState {
             Remove-Item -LiteralPath $promptDst -Force -ErrorAction SilentlyContinue
         }
 
+        # Deliberately NOT folded into the status above. A stale or unwritten
+        # tstyles.sh does not change what the next tab looks like: the rc block
+        # sources whatever is there, and the palette and prompt staged above are
+        # the new style's. shell-init is the command that promises the runtime,
+        # and it reports this failure with the path and the reason.
         [void](Sync-ShellRuntime)
-    } catch { }
+        return 'ok'
+    } catch {
+        $script:TStylesShellStagingError = $_.Exception.Message
+        return 'failed'
+    }
+}
+
+function Show-ShellStagingFailure {
+    # The notice both apply doors print when Set-ShellStyleState could not
+    # stage. Written once on purpose: `tstyles <name>` and the picker stage the
+    # same two files, they have already drifted apart over exactly this -- the
+    # picker did not stage them at all for several releases -- and a notice that
+    # exists on one door and not the other is the defect this whole file is
+    # being edited for.
+    #
+    # Leading blank line, no trailing one: the callers own their own spacing.
+    param([Parameter(Mandatory)][AllowEmptyString()][string]$Status)
+    if ($Status -eq 'ok') { return }
+    Write-Host ""
+    Write-Host ("  Could not stage the shell files under {0}: {1}" -f
+                $script:TStylesDataRoot, $script:TStylesShellStagingError) -ForegroundColor Yellow
+    Write-Host "  New zsh/bash tabs will keep the PREVIOUS style until that is fixed." -ForegroundColor Yellow
 }
 
 function Clear-ShellStyleState {
@@ -736,7 +804,17 @@ function Save-FirstTouchBackup {
 function Register-ShellLoader {
     # Add (or refresh) the loader block in one rc file. Returns the action taken
     # so the caller can report it: 'added', 'updated', 'unchanged', 'skipped',
-    # or 'failed' when the file could not be written.
+    # 'malformed', or 'failed' when the file could not be written.
+    #
+    # 'malformed' is the same state Unregister-ShellLoader names, on the same
+    # bytes: a BEGIN marker with no matching END. It was missing here, and the
+    # refresh branch below then matched nothing, wrote the file back
+    # byte-for-byte and returned 'updated' -- so shell-init printed the file in
+    # cyan as registered and told the user to `source` it, having written
+    # nothing, and said the same on every run afterwards. In the shape this
+    # state usually arrives in -- a block deleted by hand down to its first line
+    # -- there is no loader in that file at all. The status vocabulary exists so
+    # the two halves of the pair cannot disagree about what a file is.
     #
     # 'failed' rather than an exception: shell-init registers into several rc
     # files in a loop, and one unwritable file (read-only, owned by root, on a
@@ -777,6 +855,16 @@ function Register-ShellLoader {
         # copy. Refusing to cross a BEGIN makes the match fail at the stray
         # marker and start again at the real one, which is the block we own.
         $pattern = [regex]::Escape($begin) + '(?:(?!' + [regex]::Escape($begin) + ')[\s\S])*?' + [regex]::Escape($end)
+        # A BEGIN with no END to close it. Everything below assumes the span
+        # exists: the Replace would match nothing, write the identical bytes
+        # back and report 'updated'. Checked before the -Force branch, because
+        # -Force skips the comparison and went straight to that Replace.
+        #
+        # [regex]::IsMatch with the Singleline option rather than -notmatch:
+        # PowerShell's operator has no Singleline, so `.` would not cross the
+        # newlines between the markers and every ordinary multi-line block would
+        # be called malformed.
+        if (-not [regex]::IsMatch($content, $pattern, 'Singleline')) { return 'malformed' }
         if (-not $Force) {
             # Already registered. Compare the body so an upgraded data root or
             # runtime path is picked up without -Force.
@@ -886,7 +974,15 @@ function Unregister-ShellLoader {
     $begin = '# ===== TerminalStyles BEGIN ====='
     $end   = '# ===== TerminalStyles END ====='
     $enc   = Get-RcFileEncoding
-    $content = [System.IO.File]::ReadAllText($Path, $enc)
+    # The READ is guarded as well as the write. It was not, so an rc file this
+    # user cannot read threw a raw MethodInvocationException straight out of
+    # both callers -- past every remaining rc file, past the WezTerm cleanup and
+    # past the $PROFILE strip, in the middle of an uninstall. 'failed' is the
+    # right answer for the same reason it is when the write is refused: the
+    # block is still in a file we could not deal with.
+    try {
+        $content = [System.IO.File]::ReadAllText($Path, $enc)
+    } catch { return 'failed' }
     if ($content -notmatch [regex]::Escape($begin)) { return 'none' }
 
     # Tempered exactly as Register-ShellLoader's span is, and for the same
@@ -905,6 +1001,61 @@ function Unregister-ShellLoader {
     # take down a shell-remove that has already stripped others.
     try { [System.IO.File]::WriteAllText($Path, $stripped, $enc) } catch { return 'failed' }
     return 'removed'
+}
+
+function Remove-ShellLoaderBlock {
+    <#
+    .SYNOPSIS
+    Strip the loader from a list of rc files and report what happened to each.
+
+    .DESCRIPTION
+    ONE implementation of the reporting rule, because there are two callers --
+    `tstyles shell-remove` and `tstyles uninstall` -- and they diverged.
+    shell-remove switched on all four of Unregister-ShellLoader's statuses;
+    uninstall kept `if ((Unregister-ShellLoader -Path $c.Path) -eq 'removed')`,
+    which is an explicit comparison against exactly one of them and throws the
+    other three away. So an unwritable rc file (the managed-dotfile case that
+    function's docstring names) and a BEGIN with no END printed nothing at all,
+    were counted as nothing, and the command signed off on "TerminalStyles
+    uninstalled." with the block still in files its own consent screen had just
+    listed by name -- after step 1 had removed the module, so `shell-remove`
+    could no longer take them out either.
+
+    .OUTPUTS
+    [pscustomobject] Removed  = how many blocks went
+                     Problems = the paths still carrying one
+
+    The caller decides what to say about those two numbers, because the two
+    commands close on different sentences. Neither gets to decide whether a
+    failure is mentioned at all.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][AllowEmptyCollection()][string[]]$Path)
+
+    $removed = 0
+    $problems = @()
+    foreach ($p in $Path) {
+        switch (Unregister-ShellLoader -Path $p) {
+            'removed' {
+                Write-Host ("  removed the loader from {0}" -f $p) -ForegroundColor Green
+                $removed++
+            }
+            'malformed' {
+                Write-Host ("  ! {0} has a TerminalStyles BEGIN marker with no matching END." -f $p) -ForegroundColor Red
+                Write-Host "    Nothing was removed. Delete the block by hand -- it still loads on every shell." -ForegroundColor Red
+                $problems += $p
+            }
+            'failed' {
+                Write-Host ("  ! could not write {0}" -f $p) -ForegroundColor Red
+                Write-Host "    The loader is still there. Check the file's permissions (a read-only" -ForegroundColor Red
+                Write-Host "    dotfile, or a symlink into a managed store) and remove the block by hand." -ForegroundColor Red
+                $problems += $p
+            }
+            # 'none' is the ordinary case for an rc file that never carried a
+            # block, and says nothing on purpose.
+        }
+    }
+    [pscustomobject]@{ Removed = $removed; Problems = @($problems) }
 }
 
 function Invoke-TerminalStylesShellInit {
@@ -941,30 +1092,17 @@ function Invoke-TerminalStylesShellInit {
         # place while reporting the loader removed.
         $candidates = Get-ShellRcRemovalCandidate @splat
 
-        # Each status reported for what it is. A failure and a malformed block
-        # both used to read as "nothing was registered", so the user was told
-        # the loader was gone while every new shell still sourced it.
-        $removed = 0
-        $problems = @()
-        foreach ($c in $candidates) {
-            switch (Unregister-ShellLoader -Path $c.Path) {
-                'removed' {
-                    Write-Host ("  removed from {0}" -f $c.Path) -ForegroundColor Yellow
-                    $removed++
-                }
-                'malformed' {
-                    Write-Host ("  ! {0} has a TerminalStyles BEGIN marker with no matching END." -f $c.Path) -ForegroundColor Red
-                    Write-Host "    Nothing was removed. Delete the block by hand -- it still loads on every shell." -ForegroundColor Red
-                    $problems += $c.Path
-                }
-                'failed' {
-                    Write-Host ("  ! could not write {0}" -f $c.Path) -ForegroundColor Red
-                    Write-Host "    The loader is still there. Check the file's permissions (a read-only" -ForegroundColor Red
-                    Write-Host "    dotfile, or a symlink into a managed store) and re-run." -ForegroundColor Red
-                    $problems += $c.Path
-                }
-            }
-        }
+        # Each status reported for what it is, through the helper uninstall
+        # sweeps with too. A failure and a malformed block both used to read as
+        # "nothing was registered", so the user was told the loader was gone
+        # while every new shell still sourced it.
+        #
+        # Projected with ForEach-Object rather than `$candidates.Path`: member
+        # access on an empty collection yields one $null, and a list with one
+        # empty path in it is not the same as an empty list.
+        $swept = Remove-ShellLoaderBlock -Path @($candidates | ForEach-Object { $_.Path })
+        $removed  = $swept.Removed
+        $problems = $swept.Problems
         Clear-ShellStyleState
         if ($problems.Count -gt 0) {
             Write-Host ""
@@ -978,8 +1116,16 @@ function Invoke-TerminalStylesShellInit {
         return
     }
 
-    if (-not (Sync-ShellRuntime)) {
-        Write-Error "Could not stage the shell runtime (shell/tstyles.sh missing from the module)."
+    # Two different failures, two different sentences. One boolean here named
+    # the first cause for both, so a user whose data root would not take the
+    # write was told their install was missing a file.
+    $sync = Sync-ShellRuntime
+    if ($sync -eq 'nosource') {
+        Write-Error "Could not stage the shell runtime (shell/tstyles.sh missing from the module). Reinstall TerminalStyles."
+        return
+    } elseif ($sync -ne 'ok') {
+        Write-Error ("Could not write the shell runtime into {0}: {1} Check that directory's permissions and free space." -f
+                     $script:TStylesDataRoot, $script:TStylesShellStagingError)
         return
     }
 
@@ -1146,11 +1292,16 @@ function Invoke-TerminalStylesShellInit {
             'added'     { 'Green' }
             'updated'   { 'Cyan' }
             'failed'    { 'Red' }
+            'malformed' { 'Red' }
             default     { 'Gray' }
         }
         Write-Host ("  {0,-9} {1}" -f $t.Action, $t.Path) -ForegroundColor $color
         if ($t.Action -eq 'failed') {
             Write-Host "            (could not write it -- check the file's permissions)" -ForegroundColor DarkGray
+        }
+        if ($t.Action -eq 'malformed') {
+            Write-Host "            (a TerminalStyles BEGIN marker with no matching END -- nothing" -ForegroundColor DarkGray
+            Write-Host "             was written. Delete that line by hand and run this again.)" -ForegroundColor DarkGray
         }
     }
     Write-Host ""
@@ -1164,7 +1315,11 @@ function Invoke-TerminalStylesShellInit {
     # ~/.zshrc existed was told "source ~/.bashrc" -- advice that does nothing in
     # the shell they are sitting in. Prefer a file the LOGIN shell reads; fall
     # back to the first only when none was touched.
-    $written  = @($touched | Where-Object { $_.Action -ne 'failed' })
+    #
+    # The filter is on the statuses that mean "there is no loader in this file",
+    # not on 'failed' alone: 'malformed' writes nothing either, and naming it
+    # here sent the user to `source` a file that has no loader line in it.
+    $written  = @($touched | Where-Object { $_.Action -notin @('failed', 'malformed') })
     $hintPath = (@($written | Where-Object { $_.Shell -eq $loginShell }) + $written |
                  Select-Object -First 1).Path
     if ($hintPath) {

--- a/tests/Apply-StyleNonWT.Tests.ps1
+++ b/tests/Apply-StyleNonWT.Tests.ps1
@@ -173,6 +173,107 @@ Describe 'Apply-StyleNonWT' {
     }
 }
 
+Describe 'the zsh/bash half of an apply says when it could not stage' {
+    # Set-ShellStyleState stages current-style.osc and current-prompt.sh -- the
+    # two files that decide what every FUTURE zsh/bash tab looks like -- inside
+    # one try whose catch was literally `} catch { }`, and it returned nothing.
+    # Both call sites invoked it as a bare statement, because there was nothing
+    # to check. So a write failure on the first of those files skipped the rest,
+    # left the PREVIOUS style staged, and `tstyles <style>` printed its ordinary
+    # green success block over the top of it.
+    #
+    # Best-effort is the right policy here and is documented as deliberate: a
+    # PowerShell user with no shell integration must not see an apply fail over
+    # these. Best effort still has to REPORT, and the asymmetry made that
+    # obvious -- the half that repaints THIS tab reports its failure in three
+    # careful yellow lines, and the half that decides every future tab said
+    # nothing at all.
+    InModuleScope TerminalStyles {
+        BeforeEach {
+            $script:TStylesDataRoot = Join-Path $TestDrive ([guid]::NewGuid().ToString('n'))
+            New-Item -ItemType Directory -Path $script:TStylesDataRoot -Force | Out-Null
+            $script:TStylesCurrent = Join-Path $script:TStylesDataRoot 'current-style.ps1'
+
+            $script:styleDir = Join-Path $script:TStylesDataRoot 'styles/fake'
+            New-Item -ItemType Directory -Force -Path $script:styleDir | Out-Null
+            [System.IO.File]::WriteAllText((Join-Path $script:styleDir 'scheme.json'),
+                '{"name":"fake","background":"#101010","foreground":"#f0f0f0"}',
+                [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText((Join-Path $script:styleDir 'prompt.sh'),
+                "# fake shell prompt`n", [System.Text.UTF8Encoding]::new($false))
+            $script:scheme = [pscustomobject]@{
+                name = 'fake'; background = '#101010'; foreground = '#f0f0f0'
+            }
+
+            Mock Get-TerminalKind { 'AppleTerminal' }
+            Mock Write-HostOscPacket { $false }
+            Mock Get-StyleBundledBackground { $null }
+
+            # A directory that does not exist, so [System.IO.File]::WriteAllText
+            # throws a DirectoryNotFoundException on the FIRST statement in the
+            # try -- the same shape as an unwritable data root, with no chmod,
+            # which keeps this portable to the Windows legs of CI.
+            function script:Break-Staging {
+                Mock Get-ShellOscPath { Join-Path $script:TStylesDataRoot 'no-such-dir/current-style.osc' }
+            }
+        }
+
+        It 'returns ok when it staged everything' {
+            Set-ShellStyleState -StyleName 'fake' -StyleDir $script:styleDir -Scheme $script:scheme |
+                Should -Be 'ok'
+        }
+
+        It 'returns failed rather than swallowing the write error' {
+            script:Break-Staging
+            Set-ShellStyleState -StyleName 'fake' -StyleDir $script:styleDir -Scheme $script:scheme |
+                Should -Be 'failed'
+        }
+
+        It 'the apply names the directory it could not write into' {
+            script:Break-Staging
+            $out = Apply-StyleNonWT -StyleName 'fake' -StyleDir $script:styleDir 6>&1 | Out-String
+
+            $out | Should -Match 'Could not stage'
+            $out | Should -Match ([regex]::Escape($script:TStylesDataRoot)) `
+                -Because 'the user cannot fix a directory the message never names'
+            $out | Should -Match 'PREVIOUS style' `
+                -Because 'that is what every new zsh/bash tab will come up in'
+        }
+
+        It 'stops claiming the style is saved for the next tab' {
+            # The sentence the staging failure falsifies, word for word. It is
+            # printed only when stdout is redirected, which is the case a
+            # machine might act on -- and the case every CI leg runs under.
+            if (-not [Console]::IsOutputRedirected) {
+                Set-ItResult -Skipped -Because 'that sentence is only printed to a redirected host'
+                return
+            }
+            script:Break-Staging
+            $out = Apply-StyleNonWT -StyleName 'fake' -StyleDir $script:styleDir 6>&1 | Out-String
+            $out | Should -Not -Match 'The style is saved'
+        }
+
+        It 'says none of that on an ordinary apply' {
+            # A warning printed when nothing is wrong is the same defect wearing
+            # the other hat.
+            $out = Apply-StyleNonWT -StyleName 'fake' -StyleDir $script:styleDir 6>&1 | Out-String
+            $out | Should -Not -Match 'Could not stage'
+            [System.IO.File]::ReadAllText((Get-ShellOscPath), [System.Text.UTF8Encoding]::new($false)) |
+                Should -Be (Get-SchemeOscPacket -Scheme $script:scheme) -Because 'the fixture must really stage'
+        }
+
+        It 'does not leak its status into the command output' {
+            # The call sites have to CONSUME the new return value. A bare
+            # `Set-ShellStyleState ...` statement would now emit 'ok' straight
+            # into `tstyles`' own output.
+            $out = Apply-StyleNonWT -StyleName 'fake' -StyleDir $script:styleDir 6>&1 |
+                   Where-Object { $_ -isnot [System.Management.Automation.InformationRecord] } |
+                   Out-String
+            $out.Trim() | Should -BeNullOrEmpty
+        }
+    }
+}
+
 Describe 'Reset-StyleNonWT' {
     InModuleScope TerminalStyles {
         BeforeEach {

--- a/tests/Invoke-TerminalStylesRegister.Tests.ps1
+++ b/tests/Invoke-TerminalStylesRegister.Tests.ps1
@@ -188,6 +188,106 @@ Describe 'register writes a loader the install can actually resolve' {
     }
 }
 
+Describe 'register tells the truth about a $PROFILE it could not write' {
+    # The write loop had no status at all: bare ReadAllText/WriteAllText, and
+    # "  Registered in <path>" printed unconditionally on the line after. So an
+    # unwritable $PROFILE -- read-only bit, root-owned, a OneDrive lock or a
+    # Files-On-Demand placeholder -- produced a red .NET error AND a green
+    # "Registered in" line for the same file, and the command still closed on
+    # "TerminalStyles will auto-load on every new shell tab." A user who
+    # scrolled past the red, or whose second engine failed while the first
+    # succeeded, had a real success line sitting beside a fake one.
+    #
+    # Register-ShellLoader does this same job for rc files and has returned
+    # 'failed' instead of throwing since the release its header describes. This
+    # is the other half of that symmetry.
+    InModuleScope TerminalStyles {
+        BeforeEach {
+            $script:d = Join-Path $TestDrive ([guid]::NewGuid().ToString('n'))
+            New-Item -ItemType Directory -Path $script:d -Force | Out-Null
+            $script:good = Join-Path $script:d 'good-profile.ps1'
+            $script:bad  = Join-Path $script:d 'bad-profile.ps1'
+            foreach ($p in $script:good, $script:bad) {
+                [System.IO.File]::WriteAllText($p, "# my own profile`r`n",
+                    [System.Text.UTF8Encoding]::new($false))
+            }
+            # IsReadOnly rather than chmod: one .NET attribute on every platform
+            # the suite runs on. Cleared in AfterEach so TestDrive can be removed.
+            (Get-Item -LiteralPath $script:bad -Force).IsReadOnly = $true
+
+            function script:New-Target([string]$Path, [string]$Label) {
+                [pscustomobject]@{ Label = $Label; ProfilePath = $Path; Exists = $true; HasLoader = $false }
+            }
+        }
+        AfterEach { (Get-Item -LiteralPath $script:bad -Force).IsReadOnly = $false }
+
+        It 'does not report a file it could not write as registered' {
+            $out = Invoke-TerminalStylesRegister -Yes 6>&1 -Targets @(
+                (script:New-Target $script:good 'PowerShell 7')
+                (script:New-Target $script:bad  'Windows PowerShell 5.1')
+            ) | Out-String
+
+            $out | Should -Match ("Registered in " + [regex]::Escape($script:good))
+            $out | Should -Not -Match ("Registered in " + [regex]::Escape($script:bad)) `
+                -Because 'nothing was written to it'
+            $out | Should -Match 'could not write'
+            $out | Should -Match ([regex]::Escape($script:bad))
+
+            [System.IO.File]::ReadAllText($script:good) | Should -Match 'TerminalStyles BEGIN'
+            [System.IO.File]::ReadAllText($script:bad)  | Should -Be "# my own profile`r`n"
+        }
+
+        It 'still writes every other target, and still promises auto-load for them' {
+            $out = Invoke-TerminalStylesRegister -Yes 6>&1 -Targets @(
+                (script:New-Target $script:bad  'Windows PowerShell 5.1')
+                (script:New-Target $script:good 'PowerShell 7')
+            ) | Out-String
+
+            # Order matters: the failing target is FIRST, so a loop that unwinds
+            # never reaches the one that would have worked.
+            [System.IO.File]::ReadAllText($script:good) | Should -Match 'TerminalStyles BEGIN'
+            $out | Should -Match 'auto-load on every new shell tab'
+            $out | Should -Match 'Not registered in'
+        }
+
+        It 'does not promise auto-load when every target failed' {
+            $out = Invoke-TerminalStylesRegister -Yes 6>&1 -Targets @(
+                (script:New-Target $script:bad 'Windows PowerShell 5.1')
+            ) | Out-String
+
+            $out | Should -Not -Match 'auto-load on every new shell tab' `
+                -Because 'no shell tab will load anything'
+            $out | Should -Not -Match 'To verify in this session'
+        }
+
+        It 'leaves no backup of a profile it never modified, however often it is retried' {
+            # Save-FirstTouchBackup runs BEFORE the write, so the failing target
+            # got a <profile>.bak-<timestamp> copy of a file that never changed
+            # -- and since the block never lands, the next run took another.
+            Invoke-TerminalStylesRegister -Yes -Targets @((script:New-Target $script:bad 'x')) 6>&1 | Out-Null
+            Start-Sleep -Milliseconds 1100   # the stamp is to the second
+            Invoke-TerminalStylesRegister -Yes -Targets @((script:New-Target $script:bad 'x')) 6>&1 | Out-Null
+
+            @(Get-ChildItem -LiteralPath $script:d -Filter 'bad-profile.ps1.bak-*' -Force).Count |
+                Should -Be 0 -Because 'a backup of an unmodified file is litter, and it compounds'
+        }
+
+        It 'does not throw out of the command under $ErrorActionPreference = Stop' {
+            # A user profile that sets Stop, or `tstyles register -ErrorAction
+            # Stop`. Under the shell default the unguarded .NET exception is
+            # non-terminating for the loop; under Stop it unwound the whole
+            # command, after printing "Registered in" for a file it had not
+            # written.
+            $ErrorActionPreference = 'Stop'
+            { Invoke-TerminalStylesRegister -Yes -Targets @(
+                (script:New-Target $script:bad  'Windows PowerShell 5.1')
+                (script:New-Target $script:good 'PowerShell 7')
+              ) 6>&1 | Out-Null } | Should -Not -Throw
+            [System.IO.File]::ReadAllText($script:good) | Should -Match 'TerminalStyles BEGIN'
+        }
+    }
+}
+
 Describe 'register and install.ps1 agree on what a loader line looks like' {
     # install.ps1 is fetched and piped to iex before the module exists, so it
     # cannot dot-source lib/ and the two loader forms are necessarily written

--- a/tests/Picker-ShellStateStaging.Tests.ps1
+++ b/tests/Picker-ShellStateStaging.Tests.ps1
@@ -88,6 +88,48 @@ Describe 'the picker stages shell state on confirm' {
         (script:Get-CalledCommandName -FunctionAst $fn) | Should -Contain 'Set-ShellStyleState'
     }
 
+    It 'both apply doors report a staging failure, through the same notice' {
+        # Structural for the same reason the rest of this file is: the picker's
+        # confirm branch sits behind an interactive-stdin guard that Pester can
+        # never satisfy. Apply-StyleNonWT's half of this IS driven, in
+        # tests/Apply-StyleNonWT.Tests.ps1; this is what stops the picker from
+        # quietly going silent again, which is the exact way it drifted before.
+        foreach ($name in 'Invoke-TerminalStyle', 'Apply-StyleNonWT') {
+            $fn = script:Get-FunctionAst -Name $name
+            $fn | Should -Not -BeNullOrEmpty
+            (script:Get-CalledCommandName -FunctionAst $fn) | Should -Contain 'Show-ShellStagingFailure' `
+                -Because "$name stages the shell side, so it has to say when that failed"
+        }
+    }
+
+    It 'every Set-ShellStyleState call consumes the status it returns' {
+        # Staging returns 'ok' / 'failed' now, because its catch used to be
+        # `} catch { }` and a failure left every future zsh/bash tab on the
+        # PREVIOUS style while the command printed "Style applied". A call site
+        # that drops that value is back where it started -- and worse, a bare
+        # statement would emit the status straight into `tstyles`' output.
+        $calls = @(foreach ($a in $script:asts) {
+            $a.FindAll({
+                param($n)
+                $n -is [System.Management.Automation.Language.CommandAst] -and
+                $n.GetCommandName() -eq 'Set-ShellStyleState'
+            }, $true)
+        })
+
+        $calls.Count | Should -BeGreaterOrEqual 2 -Because 'both apply paths stage the shell side'
+        foreach ($c in $calls) {
+            $pipeline = $c.Parent
+            $consumed =
+                ($pipeline -is [System.Management.Automation.Language.PipelineAst] -and
+                 $pipeline.PipelineElements.Count -gt 1) -or
+                ($pipeline.Parent -is [System.Management.Automation.Language.AssignmentStatementAst]) -or
+                ($pipeline.Parent -is [System.Management.Automation.Language.ParenExpressionAst]) -or
+                ($pipeline.Parent -is [System.Management.Automation.Language.SubExpressionAst])
+            $consumed | Should -BeTrue -Because ("the call at {0}:{1} drops the staging status" -f
+                (Split-Path -Leaf $c.Extent.File), $c.Extent.StartLineNumber)
+        }
+    }
+
     It 'every Set-ShellStyleState call passes a Scheme' {
         # Set-ShellStyleState computes current-style.osc from -Scheme. Omitting
         # it is a Mandatory-parameter prompt at confirm time, on a screen the

--- a/tests/Shell-Integration.Tests.ps1
+++ b/tests/Shell-Integration.Tests.ps1
@@ -710,7 +710,9 @@ Describe 'the shell shim does not pin a PSGallery install to one version' {
             Mock Get-TStylesDataRoot { Join-Path $TestDrive 'some-other-data-root' }
             Get-TerminalStylesInstallKind | Should -Be 'PSResourceGet' -Because 'the fixture must set the branch under test'
 
-            Sync-ShellRuntime | Should -BeTrue
+            # -Be 'ok', not -BeTrue. Every status this returns is a non-empty
+            # string, so -BeTrue is now satisfied by 'failed' as well.
+            Sync-ShellRuntime | Should -Be 'ok'
             $shim = [System.IO.File]::ReadAllText((Get-ShellCliPath))
 
             $shim | Should -Match '(?m)^Import-Module TerminalStyles -DisableNameChecking\s*$'
@@ -722,7 +724,7 @@ Describe 'the shell shim does not pin a PSGallery install to one version' {
             Mock Get-TStylesDataRoot { $script:TStylesModuleRoot }
             Get-TerminalStylesInstallKind | Should -Be 'Bootstrap'
 
-            Sync-ShellRuntime | Should -BeTrue
+            Sync-ShellRuntime | Should -Be 'ok'
             $shim = [System.IO.File]::ReadAllText((Get-ShellCliPath))
 
             $shim | Should -Match 'TerminalStyles\.psd1' `
@@ -737,6 +739,165 @@ Describe 'the shell shim does not pin a PSGallery install to one version' {
             Sync-ShellRuntime | Out-Null
             [System.IO.File]::ReadAllText((Get-ShellCliPath)) |
                 Should -Match '\$global:TStylesNoAutoLoad\s*=\s*\$true'
+        }
+    }
+}
+
+Describe 'Register-ShellLoader refuses a BEGIN with no matching END' {
+    # The registration half of the pair had no answer for a state its own
+    # sibling has a name for. Given a file whose END marker is gone --
+    # hand-edited rc, interrupted write, a half-finished manual cleanup, the
+    # inputs Unregister-ShellLoader's docstring already enumerates -- the
+    # refresh branch matched nothing, wrote the identical bytes back, and
+    # returned 'updated'. shell-init printed `updated  ~/.zshrc` in cyan and
+    # told the user to `source` it, with no loader line in the file at all, and
+    # every re-run said the same thing: an absorbing state the tool could never
+    # talk the user out of.
+    InModuleScope TerminalStyles {
+        BeforeEach {
+            $script:TStylesDataRoot = $TestDrive
+            $script:h = Join-Path $TestDrive ([guid]::NewGuid().ToString('n'))
+            New-Item -ItemType Directory -Path $script:h -Force | Out-Null
+            $script:rc = Join-Path $script:h '.zshrc'
+            # The state the finding was measured on, and the one a user reaches
+            # by following shell-remove's own advice ("Delete the block by
+            # hand") imprecisely: the marker left behind, the loader line gone.
+            # Nothing sources anything out of this file.
+            [System.IO.File]::WriteAllText($script:rc,
+                "alias g=git`n# ===== TerminalStyles BEGIN =====`n",
+                [System.Text.UTF8Encoding]::new($false))
+        }
+
+        It 'reports malformed rather than updated' {
+            Register-ShellLoader -Path $script:rc | Should -Be 'malformed'
+        }
+
+        It 'says the same under -Force, which used to write the file back anyway' {
+            Register-ShellLoader -Path $script:rc -Force | Should -Be 'malformed'
+        }
+
+        It 'says the same when it is the END line alone that was deleted' {
+            # The other route in, and the fixture shell-remove's own malformed
+            # test uses: a block this code wrote, with the END marker taken out.
+            # The loader line survives there, so the file still works -- but the
+            # refresh can no longer maintain it, and shell-remove will not strip
+            # it, which is exactly what the status is for.
+            $rc2 = Join-Path $script:h '.bashrc'
+            [System.IO.File]::WriteAllText($rc2, "alias g=git`n", [System.Text.UTF8Encoding]::new($false))
+            Register-ShellLoader -Path $rc2 | Should -Be 'added'
+            $t = [System.IO.File]::ReadAllText($rc2, [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText($rc2,
+                ($t -replace '# ===== TerminalStyles END =====\r?\n?', ''),
+                [System.Text.UTF8Encoding]::new($false))
+
+            Register-ShellLoader -Path $rc2 | Should -Be 'malformed'
+        }
+
+        It 'gives the same answer as Unregister-ShellLoader on the same bytes' {
+            # One file, one state, one name for it. The status vocabulary exists
+            # so the two halves of the pair cannot disagree about what happened.
+            $status = Register-ShellLoader -Path $script:rc
+            $status | Should -Be (Unregister-ShellLoader -Path $script:rc)
+        }
+
+        It 'leaves the file exactly as it found it' {
+            $before = [System.IO.File]::ReadAllBytes($script:rc)
+            [void](Register-ShellLoader -Path $script:rc -Force)
+            [System.IO.File]::ReadAllBytes($script:rc) | Should -Be $before
+        }
+
+        It 'shell-init says so and does not send the user to source that file' {
+            # The line the user actually acts on. It is chosen by a filter that
+            # only excluded 'failed', so a file reported as 'updated' with no
+            # loader in it was the file they were told to source.
+            $prev = $env:SHELL
+            try {
+                $env:SHELL = '/bin/zsh'
+                $out = Invoke-TerminalStylesShellInit -HomeDir $script:h 6>&1 | Out-String
+            } finally { $env:SHELL = $prev }
+
+            $out | Should -Match 'malformed'
+            $out | Should -Match 'no matching END'
+            $out | Should -Not -Match 'source ' `
+                -Because 'sourcing a file with no loader in it does nothing, twice'
+            $out | Should -Not -Match '(?m)^\s+updated\s'
+
+            [System.IO.File]::ReadAllText($script:rc, [System.Text.UTF8Encoding]::new($false)) |
+                Should -Not -Match 'tstyles\.sh' -Because 'nothing was registered, whatever it printed'
+        }
+    }
+}
+
+Describe 'Sync-ShellRuntime says WHICH staging failure happened' {
+    # One boolean for two unrelated causes: "shell/tstyles.sh is absent from the
+    # module" and "the data root would not take the copy". shell-init turned
+    # that single bit into "Could not stage the shell runtime (shell/tstyles.sh
+    # missing from the module)" -- a cause it cannot know, and one that sends a
+    # user whose data root is read-only, root-owned or full off to reinstall the
+    # module, the one action that cannot help. The path really at fault was
+    # never printed at all.
+    InModuleScope TerminalStyles {
+        BeforeEach {
+            $script:savedData   = $script:TStylesDataRoot
+            $script:savedModule = $script:TStylesModuleRoot
+            $script:h = Join-Path $TestDrive ([guid]::NewGuid().ToString('n'))
+            New-Item -ItemType Directory -Path $script:h -Force | Out-Null
+            $script:data = Join-Path $script:h 'data'
+            New-Item -ItemType Directory -Path $script:data -Force | Out-Null
+            $script:TStylesDataRoot = $script:data
+        }
+        AfterEach {
+            $script:TStylesDataRoot   = $script:savedData
+            $script:TStylesModuleRoot = $script:savedModule
+        }
+
+        It 'returns ok when it staged the runtime' {
+            Sync-ShellRuntime | Should -Be 'ok'
+            Test-Path -LiteralPath (Get-ShellRuntimePath) | Should -BeTrue
+        }
+
+        It 'returns nosource when the module really is missing shell/tstyles.sh' {
+            $script:TStylesModuleRoot = Join-Path $script:h 'no-shell-dir'
+            New-Item -ItemType Directory -Path $script:TStylesModuleRoot -Force | Out-Null
+            Sync-ShellRuntime | Should -Be 'nosource'
+        }
+
+        It 'returns failed when the source is there and the write is refused' {
+            # A mock rather than chmod: the Windows legs of CI have no chmod
+            # semantics for a directory, and the cause under test is "the copy
+            # was refused", whatever refused it.
+            Test-Path -LiteralPath (Join-Path (Join-Path $script:TStylesModuleRoot 'shell') 'tstyles.sh') |
+                Should -BeTrue -Because 'the fixture must set the branch under test'
+            Mock Copy-Item { throw [System.UnauthorizedAccessException]::new('Access to the path is denied.') }
+            Sync-ShellRuntime | Should -Be 'failed'
+        }
+
+        It 'shell-init blames the module only when the module is what is missing' {
+            $script:TStylesModuleRoot = Join-Path $script:h 'no-shell-dir'
+            New-Item -ItemType Directory -Path $script:TStylesModuleRoot -Force | Out-Null
+
+            $ev = $null
+            Invoke-TerminalStylesShellInit -HomeDir $script:h -ErrorVariable ev -ErrorAction SilentlyContinue *> $null
+            # The LAST record is the command's own diagnostic -- the sentence
+            # the user is left with. Matching the whole collection would also
+            # match anything that merely leaked out of the failure underneath.
+            # @() first: -ErrorVariable hands back an ArrayList, and indexing one
+            # from the end is an array trick.
+            "$(@($ev)[-1])" | Should -Match 'missing from the module'
+        }
+
+        It 'shell-init names the data root when the data root is what refused' {
+            Mock Copy-Item { throw [System.UnauthorizedAccessException]::new('Access to the path is denied.') }
+
+            $ev = $null
+            Invoke-TerminalStylesShellInit -HomeDir $script:h -ErrorVariable ev -ErrorAction SilentlyContinue *> $null
+
+            $said = "$(@($ev)[-1])"
+            $said | Should -Not -Match 'missing from the module' `
+                -Because 'the file is there; reinstalling the module cannot help'
+            $said | Should -Match ([regex]::Escape($script:data)) `
+                -Because 'the directory that refused the write is the one the user has to fix'
+            $said | Should -Match 'denied' -Because 'the reason the write failed is the actionable half'
         }
     }
 }

--- a/tests/Uninstall-ReversesShellInit.Tests.ps1
+++ b/tests/Uninstall-ReversesShellInit.Tests.ps1
@@ -97,9 +97,16 @@ Describe 'uninstall reverses shell-init' {
             # written to is a SUBSET of the file set that must be swept, because
             # shell-init also registers into ~/.profile. Asserting the narrow name
             # here is what let that block become unremovable.
+            #
+            # The strip itself goes through Remove-ShellLoaderBlock, which is the
+            # one implementation of "unregister each file and report every
+            # status" -- uninstall's own copy of that loop kept one of the four
+            # statuses and dropped the rest. Either name satisfies the second
+            # assertion, so moving the call back inline does not fail it; the
+            # behavioural cases further down are what hold that shape.
             $src = (Get-Command Invoke-TerminalStylesUninstall).ScriptBlock.ToString()
             $src | Should -Match 'Get-ShellRcRemovalCandidate'
-            $src | Should -Match 'Unregister-ShellLoader'
+            $src | Should -Match '(Unregister-ShellLoader|Remove-ShellLoaderBlock)'
         }
 
         It 'clears the staged shell state the loader reads' {
@@ -389,12 +396,25 @@ Describe 'shell-remove tells the truth about what it did' {
             # Every status is a truthy STRING, so `if (Unregister-ShellLoader ...)`
             # is now true even for 'none' -- it would strip nothing and report
             # success for every rc file the user has.
-            foreach ($fn in 'Invoke-TerminalStylesShellInit', 'Invoke-TerminalStylesUninstall') {
+            #
+            # This lint passed for the whole life of the uninstall bug above:
+            # `if ((Unregister-ShellLoader ...) -eq 'removed')` is not a bare
+            # boolean, and it still threw 'failed' and 'malformed' away. So the
+            # behavioural cases are the ones that matter, and the counter here
+            # is the other half of the lesson -- the loop stopped covering
+            # Invoke-TerminalStylesUninstall the moment it began routing through
+            # the shared helper, and a `continue` with nothing behind it reports
+            # green.
+            $checked = 0
+            foreach ($fn in 'Invoke-TerminalStylesShellInit', 'Invoke-TerminalStylesUninstall',
+                            'Remove-ShellLoaderBlock', 'Remove-PowerShellProfileLoader') {
                 $src = (Get-Command $fn).ScriptBlock.ToString()
                 if ($src -notmatch 'Unregister-ShellLoader') { continue }
+                $checked++
                 $src | Should -Not -Match 'if \(Unregister-ShellLoader[^)]*\)\s*\{' `
                     -Because "$fn must not use the status as a bare boolean"
             }
+            $checked | Should -BeGreaterThan 0 -Because 'a loop that never iterates reports green'
         }
     }
 }
@@ -514,6 +534,170 @@ Describe 'bash login shells get the style' {
             Invoke-TerminalStylesShellInit -HomeDir $h -Force *> $null
             [System.IO.File]::ReadAllText((Join-Path $h '.bash_profile'), [System.Text.UTF8Encoding]::new($false)) |
                 Should -Match 'original \.bash_profile'
+        }
+    }
+}
+
+Describe 'both rc-removal callers report every file they could not strip' {
+    # The consent screen NAMES the rc files uninstall is about to change, one
+    # per line, and then step 2 compared Unregister-ShellLoader's four-state
+    # status against exactly one of its values. 'failed' (an unwritable rc file
+    # -- the managed-dotfile case that function's own docstring names) and
+    # 'malformed' (a BEGIN with no END) printed nothing, were counted as
+    # nothing, and the command signed off on "TerminalStyles uninstalled." with
+    # the block still in two of the files it had just listed. Step 1 has removed
+    # the module by then, so `tstyles shell-remove` -- the documented way out --
+    # is gone too, and the user was never told there was anything to remove.
+    #
+    # Run over BOTH callers of the same rule, because that is the shape of the
+    # defect: shell-remove switched on all four statuses and uninstall kept its
+    # own single-arm copy. Whichever way a future edit breaks them apart, one of
+    # these two cases goes red.
+    #
+    # Driven through the real commands, past consent, with every path they can
+    # reach inside TestDrive: -HomeDir for the rc half, a mocked data root for
+    # the staged files, the Bootstrap branch so Uninstall-PSResource is never
+    # reached, and both seams of the $PROFILE half pinned to an empty list.
+    InModuleScope TerminalStyles {
+        BeforeEach {
+            $script:h = Join-Path $TestDrive ([guid]::NewGuid().ToString('n'))
+            New-Item -ItemType Directory -Path $script:h -Force | Out-Null
+            $script:data = Join-Path $script:h 'data'
+            New-Item -ItemType Directory -Path $script:data -Force | Out-Null
+            $script:savedData = $script:TStylesDataRoot
+            $script:TStylesDataRoot = $script:data
+            Mock Get-TStylesDataRoot { $script:data }
+            Mock Get-TerminalStylesInstallKind { 'Bootstrap' }
+            # -ProfileTarget @() already pins this; the mock is the second lock
+            # on the one seam whose failure would reach the operator's own
+            # $PROFILE, because that list is discovered by RUNNING each engine.
+            Mock Get-PowerShellProfileTarget { @() }
+            Mock Confirm-Action { $true }
+
+            # Three rc files, each carrying a block this code wrote itself, in
+            # the three states Unregister-ShellLoader distinguishes.
+            $script:clean = Join-Path $script:h '.zshrc'
+            $script:stuck = Join-Path $script:h '.bashrc'
+            $script:broke = Join-Path $script:h '.profile'
+            foreach ($p in $script:clean, $script:stuck, $script:broke) {
+                [System.IO.File]::WriteAllText($p, "# original`nexport MINE=1`n",
+                    [System.Text.UTF8Encoding]::new($false))
+                Register-ShellLoader -Path $p | Should -Be 'added' -Because 'the fixture must plant a real block'
+            }
+            $t = [System.IO.File]::ReadAllText($script:broke, [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText($script:broke,
+                ($t -replace '# ===== TerminalStyles END =====\r?\n?', ''),
+                [System.Text.UTF8Encoding]::new($false))
+            # IsReadOnly rather than chmod: one .NET attribute on every platform
+            # the suite runs on, where chmod is an external binary that only
+            # happens to exist on the Windows runners.
+            (Get-Item -LiteralPath $script:stuck -Force).IsReadOnly = $true
+        }
+        AfterEach {
+            (Get-Item -LiteralPath $script:stuck -Force).IsReadOnly = $false
+            $script:TStylesDataRoot = $script:savedData
+        }
+
+        It '<caller> names both files it could not strip, and does not claim it finished' -ForEach @(
+            @{ caller = 'shell-remove'; falseClaim = 'original prompt back'
+               qualifier = 'NOT fully removed' }
+            @{ caller = 'uninstall';    falseClaim = '(?m)^TerminalStyles uninstalled\.\s*$'
+               qualifier = 'EXCEPT' }
+        ) {
+            $out = if ($caller -eq 'uninstall') {
+                Invoke-TerminalStylesUninstall -HomeDir $script:h -Yes -ProfileTarget @() 6>&1 | Out-String
+            } else {
+                Invoke-TerminalStylesShellInit -HomeDir $script:h -Remove 6>&1 | Out-String
+            }
+
+            $out | Should -Match ([regex]::Escape($script:stuck))
+            $out | Should -Match 'could not write'
+            $out | Should -Match ([regex]::Escape($script:broke))
+            $out | Should -Match 'no matching END'
+            $out | Should -Match 'by hand'
+
+            # The last line the user reads. uninstall printed its unconditionally.
+            $out | Should -Not -Match $falseClaim
+            $out | Should -Match $qualifier
+
+            # The half that makes the silence a lie rather than a cosmetic slip.
+            foreach ($p in $script:stuck, $script:broke) {
+                [System.IO.File]::ReadAllText($p, [System.Text.UTF8Encoding]::new($false)) |
+                    Should -Match 'TerminalStyles BEGIN' -Because "$p would otherwise have been reported gone"
+            }
+
+            # ...and the ordinary file still comes out clean, with the user's
+            # own line still in it.
+            $after = [System.IO.File]::ReadAllText($script:clean, [System.Text.UTF8Encoding]::new($false))
+            $after | Should -Not -Match 'TerminalStyles BEGIN'
+            $after | Should -Match 'export MINE=1'
+        }
+    }
+}
+
+Describe 'uninstall says nothing extra when every rc file came out clean' {
+    # The other direction: a command that now qualifies its sign-off must not
+    # qualify it on the ordinary path, or the qualifier stops meaning anything.
+    InModuleScope TerminalStyles {
+        It 'closes on the plain line when there was nothing to report' {
+            $h = Join-Path $TestDrive ([guid]::NewGuid().ToString('n'))
+            New-Item -ItemType Directory -Path $h -Force | Out-Null
+            $data = Join-Path $h 'data'
+            New-Item -ItemType Directory -Path $data -Force | Out-Null
+            $saved = $script:TStylesDataRoot
+            $script:TStylesDataRoot = $data
+            Mock Get-TStylesDataRoot { $data }
+            Mock Get-TerminalStylesInstallKind { 'Bootstrap' }
+            Mock Get-PowerShellProfileTarget { @() }
+            Mock Confirm-Action { $true }
+
+            $rc = Join-Path $h '.zshrc'
+            [System.IO.File]::WriteAllText($rc, "# original`n", [System.Text.UTF8Encoding]::new($false))
+            Register-ShellLoader -Path $rc | Should -Be 'added'
+
+            try {
+                $out = Invoke-TerminalStylesUninstall -HomeDir $h -Yes -ProfileTarget @() 6>&1 | Out-String
+            } finally { $script:TStylesDataRoot = $saved }
+
+            $out | Should -Match '(?m)^TerminalStyles uninstalled\.\s*$'
+            $out | Should -Not -Match 'EXCEPT'
+            [System.IO.File]::ReadAllText($rc, [System.Text.UTF8Encoding]::new($false)) |
+                Should -Not -Match 'TerminalStyles BEGIN'
+        }
+    }
+}
+
+Describe 'an rc file that cannot even be READ is a status, not a stack trace' {
+    # Found while reproducing the one above. Unregister-ShellLoader guards its
+    # WRITE and not its READ, so a file the tool has no read permission on threw
+    # a raw MethodInvocationException out of the middle of both callers -- past
+    # every remaining rc file, past the WezTerm cleanup and past the $PROFILE
+    # strip. The whole point of the status vocabulary is that one bad rc file
+    # cannot take the command down.
+    InModuleScope TerminalStyles {
+        It 'reports failed rather than throwing' {
+            if ((Get-TStylesPlatform) -eq 'Windows') {
+                Set-ItResult -Skipped -Because 'chmod is the POSIX way to make a file unreadable'; return
+            }
+            $h = Join-Path $TestDrive ([guid]::NewGuid().ToString('n'))
+            New-Item -ItemType Directory -Path $h -Force | Out-Null
+            $script:TStylesDataRoot = $TestDrive
+            $rc = Join-Path $h '.zshrc'
+            [System.IO.File]::WriteAllText($rc, "# mine`n", [System.Text.UTF8Encoding]::new($false))
+            Register-ShellLoader -Path $rc | Should -Be 'added'
+            & chmod 000 $rc
+            $readable = $true
+            try { [System.IO.File]::ReadAllText($rc) | Out-Null } catch { $readable = $false }
+            try {
+                if ($readable) {
+                    # root reads anything. Saying so beats asserting on a
+                    # fixture that never took.
+                    Set-ItResult -Skipped -Because 'this user can read a mode-000 file, so the fixture did not take'
+                    return
+                }
+                { Unregister-ShellLoader -Path $rc } | Should -Not -Throw
+                Unregister-ShellLoader -Path $rc | Should -Be 'failed'
+            } finally { & chmod 644 $rc }
         }
     }
 }

--- a/tstyles.ps1
+++ b/tstyles.ps1
@@ -1399,6 +1399,10 @@ function Invoke-TerminalStyle {
         # makes sense. Off WT there are no profiles to disambiguate -- this shell
         # IS PowerShell, so the prompt always applies.
         $isPwshTarget = $true
+        # 'ok' up front because only the non-settings-file branch stages the
+        # shell side at all: left unset, the Windows Terminal path would compare
+        # $null against 'ok' and warn about a staging step it never ran.
+        $stagedShell = 'ok'
         if ($useSettingsFile) {
             $isPwshTarget = $false
             if ($Target -eq 'defaults') {
@@ -1432,7 +1436,10 @@ function Invoke-TerminalStyle {
             # current-style.osc and current-prompt.sh on the PREVIOUS style, so
             # every new zsh/bash tab comes up in the old palette and banner --
             # while `tstyles <name>` on the same terminal gets it right.
-            Set-ShellStyleState -StyleName $selectedStyle.Name `
+            # Captured, and reported below with the confirm block: the status
+            # exists because that staging used to fail in silence, and a bare
+            # statement here would also emit 'ok' into the picker's own output.
+            $stagedShell = Set-ShellStyleState -StyleName $selectedStyle.Name `
                                 -StyleDir $selectedStyle.FullName `
                                 -Scheme $schemes[$idx] -KeepPrompt:$KeepPrompt
 
@@ -1503,6 +1510,14 @@ function Invoke-TerminalStyle {
         Write-Host "  Style applied: " -NoNewline
         Write-Host $selectedStyle.Name -ForegroundColor Green
         Write-Host ""
+
+        # The same notice `tstyles <name>` prints, from the same function, so the
+        # two doors say the same thing about the same failure. This is the door
+        # that forgot to stage those files at all for several releases.
+        if ($stagedShell -ne 'ok') {
+            Show-ShellStagingFailure -Status $stagedShell
+            Write-Host ""
+        }
 
         # The same qualifier `tstyles <name>` prints, from the same function, so
         # the two doors give the same answer. Without it the picker claimed a


### PR DESCRIPTION
Five findings from the audit ledger (2, 13, 14, 15, 16), fixed as **one defect wearing five hats**: a function that knows why it failed hands its caller a value that cannot carry the reason.

This file already had the answer. `Unregister-ShellLoader` returns `removed` / `none` / `malformed` / `failed` and its callers compare explicitly — CLAUDE.md says so. The other four places on the same paths had each collapsed a status to a boolean, or to nothing.

## Measured

Same rc file, both halves of the same marker rule:

```
rc file contents      Register     Unregister
no block              added        none
a real block          updated      removed
BEGIN, no END         updated      malformed     <- main
BEGIN, no END         malformed    malformed     <- fixed
```

`Register-ShellLoader` wrote the file back byte-for-byte and told the user it had installed the loader. Its sibling has returned `malformed` for exactly that input since 0.8.22.

## The other four

- **`uninstall`** swept rc files with `if ((Unregister-ShellLoader …) -eq 'removed')`, discarding the other three answers — so a file it had just promised to strip could keep the block, with nothing said and *"TerminalStyles uninstalled."* printed underneath. `shell-remove` reported all four. That duplication is what let them drift, so the sweep-and-report rule is now **one function both call**.
- **`register`** wrote both `$PROFILE` files in an unguarded loop; the second failing left the command half-applied under a promise that every new tab would auto-load. Each target is now guarded, and on failure it **removes the first-touch backup it took of a file it never modified**.
- **`Set-ShellStyleState`** swallowed every failure in the zsh/bash half of an apply in one `catch { }` — success reported while new tabs kept the old prompt.
- **`Sync-ShellRuntime`** returned one boolean for two unrelated causes, so `shell-init` blamed a missing module file whatever went wrong, including a data root that refused the write.

## Design note

A status names the *category*, which is what a caller branches on. It cannot also carry "access is denied" vs "no space left on the device" — the half the user acts on. Rather than invent a second return shape, both staging functions set one documented module-scoped variable, read only alongside a non-`ok` status.

## Found while reproducing

`Unregister-ShellLoader`'s **read** was outside its try, so an unreadable rc file threw a raw `MethodInvocationException` out of the middle of both callers instead of returning `failed`.

## Deliberately not done

`Remove-PowerShellProfileLoader` was **not** folded into the shared sweep: it already reports all four statuses, it is the `$PROFILE` list rather than the rc list, and its advice text is genuinely different ("nix or chezmoi" vs "a symlink into a managed store") with tests pinning that wording.

`Sync-ShellRuntime`'s failure is still discarded inside `Set-ShellStyleState`, deliberately — surfacing it there would make the notice say *"new tabs will keep the PREVIOUS style"* when that is false: the rc block sources whatever `tstyles.sh` is present, and the palette staged one line earlier is the new style's. Trading one false claim for another is not a fix.

## Verification

185 tests across the five touched files: **162 passed / 23 failed** against reverted source; 185/185 with the fix. The table above is my own run against both trees.

Full suite: 1732 passed, 11 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4UptB5S567PxKmMdyH8T1
