### PR TITLE
fix(delete): three claims the confirmation made that the command did not honour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **a `tstyles delete` that failed still erased the trash, and the error said nothing else had happened.** The sweep of expired trash ran BEFORE the move, so every way the delete can fail -- the folder open in an editor, a permissions refusal, a name collision at the destination -- left the collateral erasure already done while the only thing printed was that the style could not be deleted. The sweep now runs after the move has landed: the delete and the sweep are one transaction in the order the prompt describes them, and a delete that did not happen erases nothing.
+
+  Narrower than first reported, and worth recording accurately: the folders it erases ARE named in red on the same screen the user confirms, and they are past the documented seven days. What was false is the other half -- that a failed command had changed nothing.
+
+- **`tstyles delete` itemised a reset it then refused to perform, and called its own style one this tool never wrote.** Deleting the ACTIVE style on Windows Terminal prints that the profile will be reset, and the reset then runs after the style directory has already moved to the trash -- so the guard added in 0.8.22, which refuses to strip a profile whose `colorScheme` does not name a style this tool knows, could no longer see the style and refused. The user got "Deleted mine." followed by "'PowerShell' carries no TerminalStyles style -- nothing was changed. Its colorScheme is 'mine', which is not a style this tool wrote." about the style they had just deleted, with the profile left styled.
+
+  The reconciliation stays LAST, deliberately -- resetting before the move would leave the terminal unstyled if the move then threw, which is what that ordering guards. Instead the caller passes the ownership answer it already had one statement earlier, so the 0.8.22 guard is not weakened: a `colorScheme` naming something else is still refused, and a test pins that. Also fixed by the same change: `current-style.ps1` and `current-style.json` survived, so the deleted style's prompt kept loading while `tstyles current` reported nothing active.
+
+- **the delete confirmation described the opposite of what happens to a tuned child.** It said a child keeps its brightness and saturation and only loses the parent's colours; since 0.8.18 a child records a fingerprint of the base it was tuned from, and when the base goes the deltas are dropped and the child keeps the colours. Both clauses of that sentence were wrong, not one. The prompt now asks the question the tuner itself answers rather than re-deriving it from a proxy -- the plan computes what will really happen and the printer prints it, the same division the ERASE lines already use.
+
 ## [0.8.25] - 2026-09-12
 
 ### Fixed

--- a/lib/applystyle.ps1
+++ b/lib/applystyle.ps1
@@ -796,7 +796,12 @@ function Reset-StyleDirect {
     # Off Windows Terminal there is no settings.json to strip: the reset is an
     # OSC 104/110-117 packet that hands color control back to the terminal's own
     # profile, plus dropping the style record and current-style.ps1.
-    param([string]$Target)
+    #
+    # -KnownStyleName is one name the CALLER has already proved is ours, for the
+    # ownership marker below. `tstyles delete` is the only user: it proves
+    # ownership while the style is still on disk, and the reset it promised runs
+    # after the move.
+    param([string]$Target, [string]$KnownStyleName)
 
     Show-UpdateNoticeIfAvailable
 
@@ -869,9 +874,20 @@ function Reset-StyleDirect {
     # answer is to change nothing rather than guess. This runs BEFORE the backup
     # on purpose -- see Save-SettingsBackup below, whose rolling .bak is the
     # user's only undo and must not be spent on a call that writes nothing.
+    #
+    # Get-AvailableStyles enumerates styles/ under the two roots, and that is
+    # the whole of what it can see -- so the marker is false for a style that
+    # has just been moved OUT of it. `tstyles delete` does exactly that: it
+    # moves the style into .deleted/ (a sibling of styles/) and only then runs
+    # the reset it itemised on the consent screen, which refused, leaving the
+    # profile fully styled and printing "Its colorScheme is '<name>', which is
+    # not a style this tool wrote" four lines under "Deleted <name>." Resetting
+    # BEFORE the move would leave the terminal unstyled if the move then
+    # throws, so the caller carries its proof across instead.
     $styledByUs = $false
     if ($schemeName) {
-        $styledByUs = @(Get-AvailableStyles | Where-Object { $_.Name -eq $schemeName }).Count -gt 0
+        $styledByUs = ($KnownStyleName -and $schemeName -eq $KnownStyleName) -or
+                      @(Get-AvailableStyles | Where-Object { $_.Name -eq $schemeName }).Count -gt 0
     }
     if (-not $styledByUs) {
         Write-Host ("  '{0}' carries no TerminalStyles style -- nothing was changed." -f $Target) -ForegroundColor Yellow

--- a/lib/deletestyle.ps1
+++ b/lib/deletestyle.ps1
@@ -184,12 +184,25 @@ function Get-StyleTuneChild {
     anywhere else -- so the user has to be told before confirming, by name and
     by value.
 
+    KeepsAdjustments is what the delete actually does to this child, decided
+    here rather than guessed by the printer. It is false whenever the name goes
+    -- the base stops resolving, so the deltas are dropped -- and when the name
+    REVERTS to a bundled style it is the fingerprint question:
+    Test-TuneBaseMoved against -RevealDir, the same comparison Resolve-TuneSeed
+    will make the next time the child is tuned.
+
     HasFingerprint matters for the wording: a child with no baseFingerprint
     gets no "the base changed" notice on its next tune, so its adjustments
     change meaning with nothing on screen to explain it.
     #>
     [CmdletBinding()]
-    param([Parameter(Mandatory)][string]$StyleDir)
+    param(
+        [Parameter(Mandatory)][string]$StyleDir,
+        # Where the name will resolve after the delete, when it survives at all
+        # (a shadow reverting to its bundled original). Empty means the name
+        # goes with the style.
+        [AllowEmptyString()][AllowNull()][string]$RevealDir
+    )
 
     $out = @()
     foreach ($s in (Get-AvailableStyles)) {
@@ -203,11 +216,15 @@ function Get-StyleTuneChild {
         $baseDir = Get-StyleDir -StyleName ([string]$t.base)
         if (-not $baseDir) { continue }
         if (-not (Test-SameStyleDirectory -A $baseDir -B $StyleDir)) { continue }
+        $recordedFp = $(if ($t.PSObject.Properties.Match('baseFingerprint').Count) { [string]$t.baseFingerprint } else { '' })
         $out += [pscustomobject]@{
-            Name           = $s.Name
-            Brightness     = $(if ($t.PSObject.Properties.Match('brightness').Count) { [int]$t.brightness } else { 0 })
-            Saturation     = $(if ($t.PSObject.Properties.Match('saturation').Count) { [int]$t.saturation } else { 0 })
-            HasFingerprint = [bool]($t.PSObject.Properties.Match('baseFingerprint').Count -and $t.baseFingerprint)
+            Name             = $s.Name
+            Brightness       = $(if ($t.PSObject.Properties.Match('brightness').Count) { [int]$t.brightness } else { 0 })
+            Saturation       = $(if ($t.PSObject.Properties.Match('saturation').Count) { [int]$t.saturation } else { 0 })
+            HasFingerprint   = [bool]$recordedFp
+            KeepsAdjustments = $(if ($RevealDir) {
+                                     -not (Test-TuneBaseMoved -RecordedFingerprint $recordedFp -BaseDir $RevealDir)
+                                 } else { $false })
         }
     }
     return @($out)
@@ -296,7 +313,9 @@ function Get-StyleDeletePlan {
     # survives.
     try { $plan.WasActive = ((Get-CurrentStyleName) -eq $Name) } catch { }
 
-    $plan.Children = @(Get-StyleTuneChild -StyleDir $dir)
+    # After RevealDir on purpose: what a tuned child keeps depends on whether
+    # the name survives the delete, and on what it resolves to if it does.
+    $plan.Children = @(Get-StyleTuneChild -StyleDir $dir -RevealDir $plan.RevealDir)
 
     $cache = Get-StyleCacheDir -StyleName $Name
     if (Test-Path -LiteralPath $cache) { $plan.KeptCache = $cache }
@@ -391,15 +410,24 @@ function Show-StyleDeletePlan {
         }
     }
 
+    # On KeepsAdjustments, not on which branch of the delete this is. A child
+    # keeps its deltas only where the base its fingerprint was taken from is
+    # still what the name resolves to, so the reveal branch said "same
+    # brightness/saturation" in Gray while the tuner dropped them to 0, for
+    # every child saved since the fingerprint was introduced.
     foreach ($c in $Plan.Children) {
-        if ($Plan.RevealDir) {
+        if ($c.KeepsAdjustments) {
             Write-Host ("  - '{0}' was tuned from this style and re-seeds from the bundled one: same brightness/saturation, different colours" -f $c.Name) -ForegroundColor Gray
             if (-not $c.HasFingerprint) {
                 Write-Host ("      it records no base fingerprint, so its next tune will not mention the change") -ForegroundColor DarkGray
             }
         } else {
             Write-Host ("  - '{0}' loses the brightness {1:+#;-#;0} and saturation {2:+#;-#;0} it was tuned by" -f $c.Name, $c.Brightness, $c.Saturation) -ForegroundColor Red
-            Write-Host ("      nothing else records those values") -ForegroundColor DarkGray
+            if ($Plan.RevealDir) {
+                Write-Host ("      they were measured against your '{0}', not the bundled one; nothing else records them, and its own colours do not change" -f $Plan.Name) -ForegroundColor DarkGray
+            } else {
+                Write-Host ("      nothing else records those values") -ForegroundColor DarkGray
+            }
         }
     }
 
@@ -487,34 +515,18 @@ function Move-StyleDirectoryToTrash {
 
     Old trash is swept here rather than by a separate command, so the store
     cannot grow without bound -- the very complaint this feature exists to fix.
+
+    The reversible step runs FIRST and the irreversible one LAST. It was the
+    other way round, so every ordinary way the move can fail -- the folder open
+    in an editor on Windows, a permissions failure, the style removed by hand or
+    by a second terminal between the plan and the keystroke -- still erased the
+    expired trash for good, while the only thing printed was that the style
+    could NOT be deleted.
     #>
     [CmdletBinding()]
     param([Parameter(Mandatory)]$Plan)
 
     $trashRoot = Get-StyleTrashRoot
-
-    # Sweep the list the user was SHOWN, off the plan -- not a fresh one.
-    # Calling Get-StyleTrashSweepTarget again here would re-read the clock AFTER
-    # the prompt, and Confirm-Action blocks for as long as the user takes to
-    # read it: a folder sitting at six days and twenty-three hours when the
-    # listing was drawn crosses the window while they decide, and confirming
-    # erases it having never named it. That is this same defect one step later,
-    # and it is why the window is not a parameter here -- a second place to set
-    # it is a second answer to disagree with the first.
-    #
-    # A plan carrying no SweepTargets sweeps nothing, which is the safe
-    # direction to fail: the trash grows rather than losing something unnamed.
-    if (Test-Path -LiteralPath $trashRoot) {
-        foreach ($old in @($Plan.SweepTargets)) {
-            try {
-                if ($old.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
-                    [System.IO.Directory]::Delete($old.FullName, $false)
-                } else {
-                    Remove-Item -LiteralPath $old.FullName -Recurse -Force -ErrorAction Stop
-                }
-            } catch { }
-        }
-    }
 
     # Re-prove containment at the moment of the move, not just when the plan
     # was built.
@@ -528,7 +540,31 @@ function Move-StyleDirectoryToTrash {
     Move-Item -LiteralPath $Plan.Dir -Destination $Plan.TrashPath -ErrorAction Stop
 
     if ((Test-Path -LiteralPath $Plan.Dir) -or -not (Test-Path -LiteralPath $Plan.TrashPath)) {
-        throw "Move did not complete: '$($Plan.Dir)' -> '$($Plan.TrashPath)'. Nothing else was changed."
+        throw "Move did not complete: '$($Plan.Dir)' -> '$($Plan.TrashPath)'."
+    }
+
+    # Only now, with the move verified: a delete that did not happen erases
+    # nothing.
+    #
+    # Sweep the list the user was SHOWN, off the plan -- not a fresh one.
+    # Calling Get-StyleTrashSweepTarget again here would re-read the clock AFTER
+    # the prompt, and Confirm-Action blocks for as long as the user takes to
+    # read it: a folder sitting at six days and twenty-three hours when the
+    # listing was drawn crosses the window while they decide, and confirming
+    # erases it having never named it. That is this same defect one step later,
+    # and it is why the window is not a parameter here -- a second place to set
+    # it is a second answer to disagree with the first.
+    #
+    # A plan carrying no SweepTargets sweeps nothing, which is the safe
+    # direction to fail: the trash grows rather than losing something unnamed.
+    foreach ($old in @($Plan.SweepTargets)) {
+        try {
+            if ($old.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
+                [System.IO.Directory]::Delete($old.FullName, $false)
+            } else {
+                Remove-Item -LiteralPath $old.FullName -Recurse -Force -ErrorAction Stop
+            }
+        } catch { }
     }
 }
 
@@ -616,6 +652,13 @@ function Invoke-TerminalStyleDelete {
         Move-StyleDirectoryToTrash -Plan $plan
     } catch {
         Write-Host "Could not delete '$($plan.Name)': $_" -ForegroundColor Red
+        # The listing above named trash this delete would erase, in red, and the
+        # user consented to it as part of one act. Saying the delete failed does
+        # not say that half did not happen, and the failure paths through
+        # Move-Item throw before the sweep can be reported any other way.
+        if (@($plan.SweepTargets).Count -gt 0) {
+            Write-Host "  Nothing was erased: the trash is swept only after the move lands." -ForegroundColor DarkGray
+        }
         return
     }
 
@@ -626,12 +669,15 @@ function Invoke-TerminalStyleDelete {
     if ($plan.KeptProfile) { Write-Host "  Kept $($plan.KeptProfile)" -ForegroundColor DarkGray }
 
     # Reconciliation LAST, and only once the move is verified, so a failed move
-    # never repaints the terminal.
+    # never repaints the terminal. The cost of that order is that the style is
+    # no longer where the reset looks for it: -KnownStyleName carries the
+    # ownership the plan proved while it was still there, or the reset refuses
+    # the one profile it is certain about and the RESET line above is a lie.
     if ($plan.WasActive) {
         if ($plan.RevealDir) {
             Apply-StyleDirect -StyleName $plan.Name -Target $Target
         } else {
-            Reset-StyleDirect -Target $Target
+            Reset-StyleDirect -Target $Target -KnownStyleName $plan.Name
         }
     }
 }

--- a/lib/tune.ps1
+++ b/lib/tune.ps1
@@ -257,6 +257,45 @@ function Get-StyleSchemeFingerprint {
     } catch { return $null }
 }
 
+function Test-TuneBaseMoved {
+    <#
+    .SYNOPSIS
+    Has the base a tuned style recorded been re-baked since that save?
+
+    .DESCRIPTION
+    One place answers it, because two places already disagreed. Resolve-TuneSeed
+    asks before deciding whether the recorded deltas still mean anything, and
+    the delete prompt asks before telling the user what will happen to a tuned
+    child when the style it was tuned from is moved aside. The prompt's own
+    answer was "a child with no fingerprint is the one that loses its
+    adjustments", which is the case that keeps them, so it promised in Gray --
+    the colour reserved for what is KEPT -- that the knobs survived, on every
+    child saved since the fingerprint was introduced.
+
+    "Unknown" is NOT "changed", in both of its shapes, because reading it as
+    changed discards the user's deltas and the next save then records the style
+    as its own base, severing the lineage for good:
+      * a tune.json written before the fingerprint existed records none;
+      * a base whose scheme.json cannot be READ -- a lock, a permission denial,
+        an antivirus hold -- fingerprints as $null.
+    Both answer $false.
+
+    Only meaningful when the base is a DIFFERENT directory; a self-referential
+    or missing base is the CALLER's question and is decided before this is
+    asked.
+    #>
+    [CmdletBinding()]
+    param(
+        [AllowEmptyString()][AllowNull()][string]$RecordedFingerprint,
+        [Parameter(Mandatory)][string]$BaseDir
+    )
+
+    if (-not $RecordedFingerprint) { return $false }
+    $currentFp = Get-StyleSchemeFingerprint -StyleDir $BaseDir
+    if (-not $currentFp) { return $false }
+    return ($RecordedFingerprint -ne $currentFp)
+}
+
 function Save-TunedStyle {
     # Materializes a tuned style into $DataRoot\styles\$SaveName\:
     #   scheme.json (adjusted colors, name = $SaveName)
@@ -503,9 +542,9 @@ function Resolve-TuneSeed {
                 # that in. Fall through to own-theme seeding instead, the same
                 # way the self-reference guard above does.
                 #
-                # A tune.json written before the fingerprint existed has none;
-                # that is "unknown", not "changed", so those keep seeding as
-                # they always did rather than silently losing their knobs.
+                # Test-TuneBaseMoved is where that comparison lives, because the
+                # delete prompt has to answer the same question about a tuned
+                # child before the style it descends from is moved aside.
                 $recordedFp = [string]$tune.baseFingerprint
                 $baseMoved  = $false
                 # Only meaningful when the base is a DIFFERENT directory. An
@@ -548,15 +587,8 @@ function Resolve-TuneSeed {
                     $seed.ChangedBaseName = [string]$tune.base
                     $seed.LineageBase     = [string]$tune.base
                 }
-                if (-not $baseIsSelf -and $recordedFp) {
-                    $currentFp = Get-StyleSchemeFingerprint -StyleDir $resolvedBaseDir
-                    # $null means the base could not be READ -- a lock, a
-                    # permission denial, an antivirus hold. That is "unknown",
-                    # exactly as a missing recorded fingerprint is, and must not
-                    # be read as "changed": doing so discarded the user's
-                    # deltas and, on save, rewrote tune.json with the style as
-                    # its own base, severing the lineage for good.
-                    if ($currentFp) { $baseMoved = ($recordedFp -ne $currentFp) }
+                if (-not $baseIsSelf) {
+                    $baseMoved = Test-TuneBaseMoved -RecordedFingerprint $recordedFp -BaseDir $resolvedBaseDir
                 }
                 if ($baseMoved) {
                     $seed.BaseChanged = $true

--- a/tests/Delete-Style.Tests.ps1
+++ b/tests/Delete-Style.Tests.ps1
@@ -527,6 +527,46 @@ Describe 'the delete prompt discloses what confirming it will erase' {
             }
         }
 
+        Context 'a delete that did not happen erases nothing' {
+            # The sweep is the one irreversible thing `tstyles delete` does, and
+            # it ran FIRST -- before the containment re-proof and before the
+            # move. So every ordinary way the move can fail (the folder open in
+            # an editor on Windows, a permissions failure, the style removed by
+            # hand or by a second terminal between the plan and the keystroke)
+            # destroyed the expired trash anyway, printed one red line about the
+            # style that was NOT deleted, and said nothing about what it had
+            # erased. A failed command reads as a command that did nothing.
+            It 'keeps the trash the prompt named when the move fails' {
+                $doomed = script:New-Trash 'precious-20200101-000000'
+                $plan   = Get-StyleDeletePlan -Name 'mine'
+                @($plan.SweepTargets.Name) | Should -Be @('precious-20200101-000000') `
+                    -Because 'otherwise the sweep has nothing to erase and this measures nothing'
+
+                # The style removed between the plan and the 'y' -- a second
+                # terminal, or a hand `rm`. Move-Item -ErrorAction Stop throws.
+                Remove-Item -LiteralPath $plan.Dir -Recurse -Force
+
+                { Move-StyleDirectoryToTrash -Plan $plan } | Should -Throw
+
+                [System.IO.Directory]::Exists($doomed) | Should -BeTrue `
+                    -Because 'the delete did not happen, so nothing it was bundled with may happen either'
+            }
+
+            It 'tells the user the trash is intact when the delete fails' {
+                # The other half: the ERASE lines were on the consent screen, so
+                # after a failure the user is entitled to know they did not run.
+                $doomed = script:New-Trash 'precious-20200101-000000'
+                Mock Move-Item { throw 'Access to the path is denied.' }
+
+                $out = Invoke-TerminalStyleDelete -Name 'mine' -Yes 6>&1 | Out-String
+
+                $out | Should -Match "Could not delete 'mine'"
+                $out | Should -Match 'Nothing was erased'
+                [System.IO.Directory]::Exists($doomed) | Should -BeTrue
+                Get-StyleDir -StyleName 'mine' | Should -Not -BeNullOrEmpty
+            }
+        }
+
         Context 'the listing and the sweep cannot drift apart' {
             It 'erases exactly what the prompt named, and nothing else' {
                 $doomed  = script:New-Trash 'precious-20200101-000000'
@@ -633,6 +673,185 @@ Describe 'the trash stamp is written in the calendar the sweep reads' {
 
             @(Get-StyleTrashSweepTarget).Name | Should -Not -Contain (Split-Path $plan.TrashPath -Leaf) `
                 -Because '"Kept for 7 days" was printed about it one statement ago'
+        }
+    }
+}
+
+# The consent screen itemises "RESET the terminal to its unstyled default,
+# because '<name>' is active", and then did not reset.
+#
+# Invoke-TerminalStyleDelete moves the style into .deleted/ and only afterwards
+# calls Reset-StyleDirect, whose ownership marker is "does Get-AvailableStyles
+# know the profile's colorScheme". .deleted is a SIBLING of styles/, so the one
+# style that marker is guaranteed to be true of is the one the move just hid:
+# the reset refused, the profile kept colorScheme, opacity, useAcrylic, font and
+# any background, and the output contradicted itself four lines apart --
+# "Deleted mine." in green, then "Its colorScheme is 'mine', which is not a
+# style this tool wrote."
+#
+# Windows Terminal only: every other terminal returns into Reset-StyleNonWT
+# before the marker is consulted, so the OSC reset always fired there.
+Describe 'deleting the active style performs the reset the prompt itemised' {
+    InModuleScope TerminalStyles {
+        BeforeEach {
+            $script:savedData    = $script:TStylesDataRoot
+            $script:savedModule  = $script:TStylesModuleRoot
+            $script:savedCurrent = $script:TStylesCurrent
+
+            $script:root = Join-Path $TestDrive ([guid]::NewGuid().ToString('n'))
+            $script:TStylesDataRoot   = $script:root
+            $script:TStylesModuleRoot = $script:root
+            $script:TStylesCurrent    = Join-Path $script:root 'current-style.ps1'
+
+            script:New-Style $script:root 'eva' | Out-Null
+            $script:mineDir = script:New-Style $script:root 'mine' -Tuned
+            # WasActive is a byte-compare of current-style.ps1 against each
+            # style's profile.ps1, so the style needs one and it has to match.
+            [System.IO.File]::WriteAllText((Join-Path $script:mineDir 'profile.ps1'), '# mine prompt')
+            [System.IO.File]::WriteAllText($script:TStylesCurrent, '# mine prompt')
+            [System.IO.File]::WriteAllText((Join-Path $script:root '.installed-files'), "styles/eva`n")
+
+            $script:fakeSettings = Join-Path $script:root 'settings.json'
+            $obj = [pscustomobject]@{
+                schemes  = @([pscustomobject]@{ name = 'mine' })
+                profiles = [pscustomobject]@{
+                    list = @([pscustomobject]@{
+                        name = 'PS'; guid = '{x}'; colorScheme = 'mine'; opacity = 80; useAcrylic = $true
+                    })
+                }
+            }
+            [System.IO.File]::WriteAllText($script:fakeSettings,
+                ($obj | ConvertTo-Json -Depth 32), [System.Text.UTF8Encoding]::new($false))
+
+            Mock Get-TerminalKind             { 'WindowsTerminal' }
+            Mock Find-WTSettingsPath          { $script:fakeSettings }
+            Mock Get-CurrentWTProfileName     { 'PS' }
+            Mock Show-UpdateNoticeIfAvailable {}
+        }
+        AfterEach {
+            $script:TStylesDataRoot   = $script:savedData
+            $script:TStylesModuleRoot = $script:savedModule
+            $script:TStylesCurrent    = $script:savedCurrent
+        }
+
+        It 'strips the profile the style it just deleted was applied to' {
+            $plan = Get-StyleDeletePlan -Name 'mine'
+            $plan.WasActive | Should -BeTrue -Because 'otherwise the RESET bullet is never printed and this measures nothing'
+            $plan.RevealDir | Should -BeNullOrEmpty -Because 'the name GOES; the shadow branch re-applies instead'
+
+            Invoke-TerminalStyleDelete -Name 'mine' -Target 'PS' -Yes 6>&1 | Out-Null
+
+            $after = [System.IO.File]::ReadAllText($script:fakeSettings, [System.Text.UTF8Encoding]::new($false)) | ConvertFrom-Json
+            $p = $after.profiles.list | Where-Object name -eq 'PS'
+            $p.PSObject.Properties.Match('colorScheme').Count | Should -Be 0
+            $p.PSObject.Properties.Match('opacity').Count     | Should -Be 0
+            $p.PSObject.Properties.Match('useAcrylic').Count  | Should -Be 0
+            @($after.schemes | Where-Object name -eq 'mine').Count | Should -Be 0 `
+                -Because 'the scheme is an orphan once the style is gone'
+            Test-Path -LiteralPath $script:TStylesCurrent | Should -BeFalse `
+                -Because 'the deleted style would otherwise keep loading its prompt in every new shell'
+        }
+
+        It 'does not call the style it just deleted one this tool never wrote' {
+            $out = Invoke-TerminalStyleDelete -Name 'mine' -Target 'PS' -Yes 6>&1 | Out-String
+
+            $out | Should -Match 'Deleted mine\.'
+            $out | Should -Not -Match 'not a style this tool wrote'
+            $out | Should -Not -Match 'nothing was changed'
+        }
+    }
+}
+
+# What the consent screen promises a TUNED CHILD of the style being deleted.
+#
+# The shadow branch printed, in Gray -- the colour this file reserves for what
+# is KEPT -- "'<child>' was tuned from this style and re-seeds from the bundled
+# one: same brightness/saturation, different colours". That is true only for a
+# tune.json with no baseFingerprint, which is the legacy shape: Save-TunedStyle
+# has written one into every tune.json since 0.8.18. With a fingerprint the
+# revealed bundled style hashes differently, Resolve-TuneSeed takes its
+# base-moved branch, and the knobs come back 0/0 -- while the DarkGray footnote
+# that exists "for the wording" fires only in the case where the sentence above
+# it is already true.
+Describe 'the prompt describes what will actually happen to a tuned child' {
+    InModuleScope TerminalStyles {
+        BeforeEach {
+            $script:savedData    = $script:TStylesDataRoot
+            $script:savedModule  = $script:TStylesModuleRoot
+            $script:savedCurrent = $script:TStylesCurrent
+
+            $script:caseRoot = Join-Path $TestDrive ([guid]::NewGuid().ToString('n'))
+            $script:dataRoot = Join-Path $script:caseRoot 'data'
+            $script:modRoot  = Join-Path $script:caseRoot 'mod'
+            $script:TStylesDataRoot   = $script:dataRoot
+            $script:TStylesModuleRoot = $script:modRoot
+            $script:TStylesCurrent    = Join-Path $script:caseRoot 'current-style.ps1'
+
+            # The bundled style and the user's shadow of it must hash
+            # differently, or the fingerprint compare has nothing to notice.
+            $script:bundledEva = script:New-Style $script:modRoot  'eva'
+            $script:shadowEva  = script:New-Style $script:dataRoot 'eva' -Tuned
+            [System.IO.File]::WriteAllText((Join-Path $script:bundledEva 'scheme.json'), '{"name":"eva","background":"#111111"}')
+            [System.IO.File]::WriteAllText((Join-Path $script:shadowEva  'scheme.json'), '{"name":"eva","background":"#222222"}')
+            $script:childDir = script:New-Style $script:dataRoot 'eva-night'
+            [System.IO.File]::WriteAllText((Join-Path $script:childDir 'scheme.json'), '{"name":"eva-night","background":"#333333"}')
+        }
+        AfterEach {
+            $script:TStylesDataRoot   = $script:savedData
+            $script:TStylesModuleRoot = $script:savedModule
+            $script:TStylesCurrent    = $script:savedCurrent
+        }
+
+        function script:New-ChildTune([bool]$Fingerprinted) {
+            $fields = @('"base":"eva"', '"brightness":-35', '"saturation":10')
+            if ($Fingerprinted) {
+                $fp = Get-StyleSchemeFingerprint -StyleDir $script:shadowEva
+                $fp | Should -Not -BeNullOrEmpty
+                $fields += ('"baseFingerprint":"' + $fp + '"')
+            }
+            [System.IO.File]::WriteAllText((Join-Path $script:childDir 'tune.json'),
+                ('{' + ($fields -join ',') + '}'))
+        }
+
+        It 'the promise matches what the next tune really does -- <Shape>' -ForEach @(
+            @{ Shape = 'a tune.json carrying a base fingerprint'; Fingerprinted = $true;  Keeps = $false }
+            @{ Shape = 'a legacy tune.json with no fingerprint';  Fingerprinted = $false; Keeps = $true  }
+        ) {
+            script:New-ChildTune $Fingerprinted
+
+            $plan = Get-StyleDeletePlan -Name 'eva'
+            $plan.Origin            | Should -Be 'shadow'
+            $plan.RevealDir         | Should -Not -BeNullOrEmpty
+            @($plan.Children).Count | Should -Be 1
+            $plan.Children[0].Name  | Should -Be 'eva-night'
+
+            $out = Show-StyleDeletePlan -Plan $plan 6>&1 | Out-String
+
+            # The delete itself, then the question the prompt was answering.
+            Move-StyleDirectoryToTrash -Plan $plan
+            $seed = Resolve-TuneSeed -StyleName 'eva-night' -StyleDir (Get-StyleDir -StyleName 'eva-night')
+
+            if ($Keeps) {
+                $seed.Brightness | Should -Be -35
+                $seed.Saturation | Should -Be 10
+                $out | Should -Match 'same brightness/saturation'
+                $out | Should -Match 'records no base fingerprint'
+            } else {
+                $seed.Brightness | Should -Be 0 -Because 'the base it was measured against is not the one the name now resolves to'
+                $seed.Saturation | Should -Be 0
+                $out | Should -Match "'eva-night' loses the brightness -35 and saturation \+10"
+                $out | Should -Not -Match 'records no base fingerprint'
+            }
+
+            # Stated once, so a rewording cannot quietly break the pairing: the
+            # screen may only promise the adjustments survive when they do.
+            if ($out -match 'same brightness/saturation') {
+                $seed.Brightness | Should -Be -35
+                $seed.Saturation | Should -Be 10
+            }
+
+            # And the plan, not the printer, is where that was decided.
+            $plan.Children[0].KeepsAdjustments | Should -Be $Keeps
         }
     }
 }

--- a/tests/Reset-StyleDirect.Tests.ps1
+++ b/tests/Reset-StyleDirect.Tests.ps1
@@ -163,6 +163,56 @@ Describe 'Reset-StyleDirect' {
             $w.PSObject.Properties.Match('colorScheme').Count | Should -Be 0
             $w.PSObject.Properties.Match('opacity').Count     | Should -Be 0
         }
+        It 'strips a style the caller has already proved is ours but the disk no longer has' {
+            # The ownership marker asks Get-AvailableStyles whether the
+            # profile's colorScheme names a style. `tstyles delete` calls this
+            # AFTER moving that style into .deleted/, which is a sibling of
+            # styles/ -- so the marker failed for the one profile it is
+            # guaranteed to be true of, and the reset the delete prompt had just
+            # itemised refused. -KnownStyleName is how the caller carries the
+            # proof it already had across the move.
+            $obj = [pscustomobject]@{
+                schemes  = @([pscustomobject]@{ name = 'trashed-style' })
+                profiles = [pscustomobject]@{
+                    list = @([pscustomobject]@{
+                        name = 'PowerShell'; guid = '{x}'; colorScheme = 'trashed-style'; opacity = 80
+                    })
+                }
+            }
+            [System.IO.File]::WriteAllText($script:fakeSettings, ($obj | ConvertTo-Json -Depth 32), [System.Text.UTF8Encoding]::new($false))
+
+            @(Get-AvailableStyles | Where-Object Name -eq 'trashed-style').Count | Should -Be 0 `
+                -Because 'the marker must have no other way to find it, or this measures nothing'
+
+            $script:written = $null
+            Reset-StyleDirect -Target 'PowerShell' -KnownStyleName 'trashed-style'
+
+            $script:written | Should -Not -BeNullOrEmpty
+            $w = $script:written.profiles.list | Where-Object name -eq 'PowerShell'
+            $w.PSObject.Properties.Match('colorScheme').Count | Should -Be 0
+            $w.PSObject.Properties.Match('opacity').Count     | Should -Be 0
+            @($script:written.schemes | Where-Object name -eq 'trashed-style').Count | Should -Be 0
+        }
+
+        It 'still refuses a profile carrying some other tool''s scheme name' {
+            # The seam is one name, not a bypass: -KnownStyleName must not turn
+            # the marker off for a profile this tool never styled.
+            $obj = [pscustomobject]@{
+                schemes  = @([pscustomobject]@{ name = 'someone-elses' })
+                profiles = [pscustomobject]@{
+                    list = @([pscustomobject]@{
+                        name = 'PowerShell'; guid = '{x}'; colorScheme = 'someone-elses'; opacity = 60
+                    })
+                }
+            }
+            [System.IO.File]::WriteAllText($script:fakeSettings, ($obj | ConvertTo-Json -Depth 32), [System.Text.UTF8Encoding]::new($false))
+
+            $script:written = $null
+            Reset-StyleDirect -Target 'PowerShell' -KnownStyleName 'trashed-style'
+
+            $script:written | Should -BeNullOrEmpty -Because 'the caller proved ownership of a different name'
+        }
+
         It 'resets the defaults profile when -Target defaults' {
             $obj = [pscustomobject]@{
                 schemes  = @([pscustomobject]@{ name = 'eva' })


### PR DESCRIPTION
Three findings from the audit ledger (8, 18, 20) — one mechanism, three code faults. The consent screen is a set of claims, and the execution path contradicted each of them.

## 20 — a failed delete still erased the trash

The sweep of expired trash ran **before** the move, so every way a delete can fail (folder open in an editor, permissions, a name collision at the destination) left the collateral erasure already done, while the only thing printed was that the style could not be deleted.

Measured against both trees:

```
                                           main    fixed
sweep target named by the prompt            precious-20200101-000000
move: threw (the delete failed)             yes     yes
trash still present after a FAILED delete   False   True
```

The sweep now runs after the move has landed.

**Narrower than the report, and recorded accurately:** the folders erased *are* named in red on the same screen the user confirms, and they *are* past the documented seven days. What was false is the other half — that a failed command had changed nothing. The implementer also dropped the report's `"Nothing else was changed."` claim after finding that string unreachable (`Move-Item -ErrorAction Stop` throws first).

## 8 — a reset it itemised and then refused

Deleting the **active** style on Windows Terminal prints that the profile will be reset. The reset runs after the style directory has already moved to the trash — so 0.8.22's guard (never strip a profile whose `colorScheme` does not name a style this tool knows) could no longer see the style, and refused:

```
Deleted mine.
'PowerShell' carries no TerminalStyles style -- nothing was changed.
Its colorScheme is 'mine', which is not a style this tool wrote.
```

…about the style just deleted, with the profile left styled.

**The reconciliation stays last, deliberately.** Resetting before the move would leave the terminal unstyled if the move then threw — which is what that ordering guards, per the file's own comment. Instead the caller passes the ownership answer it already had one statement earlier. The 0.8.22 guard is **not** weakened: a `colorScheme` naming something else is still refused, and a test pins that.

Also fixed by the same change, which the report missed: `current-style.ps1` and `current-style.json` survived, so the deleted style's prompt kept loading while `tstyles current` reported nothing active.

## 18 — the confirmation described the opposite of what happens

It said a tuned child keeps its brightness and saturation and loses only the parent's colours. Since **0.8.18** (the report said 0.8.19) a child records a fingerprint of its base; when the base goes, the deltas are dropped and the child keeps the colours. **Both clauses were wrong, not one.**

The fix does not branch on `HasFingerprint` as suggested — that is a proxy for the real question and a second implementation of a rule that already lives in `Resolve-TuneSeed`, which is the shape that produced this defect. The comparison is extracted once, the plan computes what will actually happen, and the printer prints it — the same division the ERASE lines already use. It is also right where the proxy is only nearly right: a fingerprint that still matches means the deltas survive.

## Corrections the implementer made to its own findings

- 8's report claimed "no recovery path… only way back is editing settings.json by hand". **False** — moving the trashed folder back and re-running `tstyles reset` works, and the plan's own closing line says so. Not written into the changelog.
- 18's harm was overstated: nothing is lost at delete time, only on the next save from the tuner.
- 20's headline ("destroys trash the user did not agree to lose") does not survive contact, as above.

## Worth a reviewer's eye

`-KnownStyleName` is a seam letting a caller assert ownership, and the marker it relaxes is what stands between `tstyles reset` and a user's hand-set profile fields. One caller uses it, with `$plan.Name`; a test pins that a different scheme name is still refused. A future caller passing something it has not proved would reopen the 0.8.22 defect — the parameter's doc comment says so.

## Verification

Before any fix: 52 passed / **7 failed** across the two touched test files. Each fix was also reverted **in isolation** to confirm it carries its own tests. The table above is my own run.

Full suite: 1712 passed, 11 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4UptB5S567PxKmMdyH8T1
