### PR TITLE
fix(settings): a dropped BOM, invisible styles, and a background that bled through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **every write to `settings.json` dropped a byte-order mark the file already had.** The picker documents its Esc revert as putting the file back byte-exactly, and it did not: `Write-SettingsAtomic` emits UTF-8 with no BOM unconditionally. The BOM is already gone by the picker's FIRST preview write, so repairing only the revert would have left it lost after a crash mid-preview and after Enter. Fixed in the single writer instead, which also covers apply, reset, the tuner and the font writer -- the encoding is a property of the user's file, not of the command that happened to touch it. Measured: a `settings.json` opening `EF BB BF` came back without it on every path, and now comes back with it.
+
+- **styles the tuner itself creates were invisible to every listing, including the delete consent listing that is supposed to name what goes.** `Get-AvailableStyles` enumerated with a pattern that skips a dot-prefixed directory and treats `[` and `]` as wildcards, while `Get-StyleDir` resolves both -- so a style named `.wip` or `dev[1]` could be applied by name and tuned, but never appeared in `tstyles list`, never in the picker, and never in the "these go with it" list the delete prompt prints before erasing it. The enumeration now admits exactly what `Get-StyleDir` resolves, rather than carrying a second, narrower answer to the same question. That also closes a third divergence: a directory name the resolver refuses can no longer be listed either, which is the "worse than not existing" state the resolver's own docstring exists to prevent.
+
+- **a background written to `profiles.defaults` was never cleared, so the previous style's image bled through the next style applied to a named profile.** The clear-what-we-wrote rule asked only about the key on the target entry, and a managed image inherited from `defaults` is not on it -- so applying a style that ships no background left the old one showing. The question is now asked of the background the profile actually SHOWS, through the resolver that already answers "what entry does this target name resolve to" for all four shapes `profiles` can take.
+
+  One consequence is deliberate and worth stating: when the incoming style ships no background and `profiles.defaults` carries one of ours, those fields are removed from `defaults`, so every other profile inheriting it loses that image too. That is what "one we wrote for the previously applied style gets cleared" means when the image is on `defaults`; the alternative would need a per-profile override this project cannot verify from macOS.
+
 ## [0.8.25] - 2026-09-12
 
 ### Fixed

--- a/apply.ps1
+++ b/apply.ps1
@@ -215,7 +215,7 @@ if ($payload.Ok) {
         -TargetName $Target -BackgroundImage $BackgroundImage `
         -BackgroundImageProvided $bgProvided
 
-    # --- Save settings.json (UTF-8 no BOM, atomic, full depth) ---
+    # --- Save settings.json (UTF-8, atomic, full depth; keeps any BOM) ---
     Write-SettingsFile -Path $SettingsPath -Settings $settings
     Write-Host "settings.json updated." -ForegroundColor Green
 } else {

--- a/lib/wtsettings.ps1
+++ b/lib/wtsettings.ps1
@@ -649,9 +649,34 @@ function Merge-StyleIntoSettings {
     # applied style gets cleared -- otherwise it bleeds through and the new
     # style is shown behind the old style's GIF. A background the user set
     # themselves is left alone, which is what the skip is for.
+    #
+    # "On the profile" has to mean what the profile SHOWS, not what its own
+    # entry happens to spell out: Windows Terminal resolves every named profile
+    # against profiles.defaults, so an image written there by
+    # `tstyles <style> -Target defaults` is live on this profile with nothing on
+    # its entry to show for it. Read only the entry -- as this did -- and
+    # $existingBg is $null, the ownership test is asked about nothing, the
+    # action falls to 'skip', and the next bundle-less style applied to the
+    # profile the user is sitting in is drawn behind the previous style's GIF.
+    # Asked through the shared resolver rather than reached for directly,
+    # because `profiles` is not always an object: against the legacy flat-array
+    # form or a missing key, `$Settings.profiles.defaults` is a method call on
+    # null. The resolver already answers "what entry does this target name
+    # resolve to", for all four shapes, and hands back $null when there is none.
+    $inheritedEntry = $null
+    if ($TargetName -ne 'defaults') {
+        $inheritedEntry = (Resolve-WTProfileTarget -Settings $Settings -TargetName 'defaults').Entry
+    }
+    $inheritedBg = if ($inheritedEntry -and
+                       $inheritedEntry.PSObject.Properties.Match('backgroundImage').Count -gt 0) {
+        [string]$inheritedEntry.backgroundImage
+    } else { $null }
+
+    # The profile's own key shadows the inherited one, so it is the one that
+    # answers "whose background is on screen".
     $existingBg = if ($entry.PSObject.Properties.Match('backgroundImage').Count -gt 0) {
         [string]$entry.backgroundImage
-    } else { $null }
+    } else { $inheritedBg }
 
     $bgAction = if ($applyBg) {
                     if ([string]::IsNullOrEmpty($effectiveBg)) { 'remove' } else { 'apply' }
@@ -671,6 +696,23 @@ function Merge-StyleIntoSettings {
         foreach ($bgField in $bgFields) {
             if ($entry.PSObject.Properties.Match($bgField).Count -gt 0) {
                 $entry.PSObject.Properties.Remove($bgField)
+            }
+        }
+        # And from profiles.defaults when that is where the image the profile
+        # shows actually lives: stripping the entry alone hands the profile
+        # straight back to the inherited copy, which is the same bleed one
+        # level up. Guarded on the INHERITED value being ours, separately from
+        # the decision above -- the entry can carry one of ours over a
+        # background the user chose for every profile, and that one is theirs
+        # to keep. Only 'remove' reaches here: an 'apply' writes the new
+        # style's image onto the entry, where it shadows defaults, so nothing
+        # of the old style is visible on this profile and clearing defaults
+        # would silently restyle every other profile too.
+        if ($inheritedEntry -and (Test-ManagedBackgroundPath -Path $inheritedBg)) {
+            foreach ($bgField in $bgFields) {
+                if ($inheritedEntry.PSObject.Properties.Match($bgField).Count -gt 0) {
+                    $inheritedEntry.PSObject.Properties.Remove($bgField)
+                }
             }
         }
     }
@@ -705,9 +747,45 @@ function Write-SettingsAtomic {
     # and reloads on change) can observe a half-written/empty file. A same-volume
     # rename is atomic on NTFS, so the live file is only ever the old bytes or the
     # complete new bytes -- never a truncated middle. Falls back to a direct copy
-    # if Replace/Move is unsupported (e.g. an odd filesystem). UTF-8 no BOM.
+    # if Replace/Move is unsupported (e.g. an odd filesystem). UTF-8, keeping the
+    # byte-order mark the live file already had and adding none to a new file.
     param([Parameter(Mandatory)][string]$Path, [Parameter(Mandatory)][AllowEmptyString()][string]$Json)
-    $enc = [System.Text.UTF8Encoding]::new($false)
+
+    # Whether settings.json starts with a BOM is the FILE's property, not this
+    # caller's, and the single writer is the only place that can keep it. Every
+    # snapshot in the module is taken with [File]::ReadAllText, whose overload
+    # builds its StreamReader with detectEncodingFromByteOrderMarks:true no
+    # matter which encoding it is handed -- so a leading EF BB BF is consumed as
+    # an encoding marker and is simply not in the string. Writing
+    # UTF8Encoding($false) unconditionally then dropped it, three bytes at a
+    # time, from a file the user owns: the picker's Esc and the tuner's Esc are
+    # both documented as restoring the ORIGINAL BYTES (tstyles.ps1 header,
+    # README "reverts in-memory to the exact prior bytes"), and both came back
+    # shorter than they went in. The rolling .bak is taken with Copy-Item
+    # precisely so it keeps every byte, a BOM included -- which left the backup
+    # and the live file disagreeing about the header. Sniffing here fixes the
+    # preview write, the revert, apply, reset and the font writer in one place;
+    # asking at the revert alone would still have lost it on the first preview.
+    #
+    # A missing, locked or unreadable file falls through to no BOM, which is
+    # today's behaviour and the right default for a file we are creating.
+    $hadBom = $false
+    try {
+        if (Test-Path -LiteralPath $Path) {
+            $head = [byte[]]::new(3)
+            # FileShare::ReadWrite, not OpenRead's FileShare::Read: Windows
+            # Terminal watches settings.json and may hold it open, and an
+            # exception here would silently cost the BOM on exactly the
+            # machines this runs on.
+            $fs = [System.IO.File]::Open($Path, [System.IO.FileMode]::Open,
+                                                [System.IO.FileAccess]::Read,
+                                                [System.IO.FileShare]::ReadWrite)
+            try { $read = $fs.Read($head, 0, 3) } finally { $fs.Dispose() }
+            $hadBom = ($read -eq 3 -and $head[0] -eq 0xEF -and $head[1] -eq 0xBB -and $head[2] -eq 0xBF)
+        }
+    } catch { $hadBom = $false }
+
+    $enc = [System.Text.UTF8Encoding]::new($hadBom)
     $tmp = "$Path.tstmp"
     [System.IO.File]::WriteAllText($tmp, $Json, $enc)
     try {

--- a/tests/Background-Carryover.Tests.ps1
+++ b/tests/Background-Carryover.Tests.ps1
@@ -69,16 +69,31 @@ Describe 'Background carryover between styles' {
         }
 
         function script:New-Settings {
-            param([hashtable]$ProfileProps = @{})
+            # -Defaults builds the profiles.defaults block Windows Terminal
+            # inherits into every named profile. Without it the file has no
+            # defaults at all, which is the only shape the cases below this
+            # could express -- and the reason none of them could see a
+            # background carried on defaults.
+            param([hashtable]$ProfileProps = @{}, [hashtable]$Defaults)
             $p = [pscustomobject](@{ name = 'PowerShell'; guid = '{x}' } + $ProfileProps)
-            [pscustomobject]@{ profiles = [pscustomobject]@{ list = @($p) } }
+            $profiles = [pscustomobject]@{ list = @($p) }
+            if ($PSBoundParameters.ContainsKey('Defaults')) {
+                $profiles | Add-Member -NotePropertyName defaults -NotePropertyValue ([pscustomobject]$Defaults)
+            }
+            [pscustomobject]@{ profiles = $profiles }
         }
         function script:Merge {
-            param($Settings, [string]$StyleDir)
+            param($Settings, [string]$StyleDir, [string]$TargetName = 'PowerShell')
             Merge-StyleIntoSettings -Settings $Settings -StyleDir $StyleDir `
-                -TargetName 'PowerShell' -BackgroundImage '' -BackgroundImageProvided $false
+                -TargetName $TargetName -BackgroundImage '' -BackgroundImageProvided $false
         }
         function script:GetProfile { param($S) $S.profiles.list | Where-Object name -eq 'PowerShell' }
+        function script:GetDefaults { param($S) $S.profiles.defaults }
+        function script:BgFieldCount {
+            param($Entry)
+            @(@('backgroundImage','backgroundImageOpacity','backgroundImageStretchMode','backgroundImageAlignment') |
+                Where-Object { $Entry.PSObject.Properties.Match($_).Count -gt 0 }).Count
+        }
 
         Context 'Test-ManagedBackgroundPath' {
             It 'is true for a bundled background under the module root' {
@@ -255,6 +270,102 @@ Describe 'Background carryover between styles' {
                 $out = Merge-StyleIntoSettings -Settings $afterWithBg -StyleDir $script:noBgDir `
                     -TargetName 'PowerShell' -BackgroundImage 'C:\pics\chosen.png' -BackgroundImageProvided $true
                 (script:GetProfile $out).backgroundImage | Should -Be 'C:\pics\chosen.png'
+            }
+        }
+
+        Context 'a background the target profile INHERITS from profiles.defaults' {
+            # Windows Terminal resolves every named profile against
+            # profiles.defaults, so an image written there is live on this
+            # profile too -- with nothing on the profile's own entry to show for
+            # it. The carry-over check read the entry alone, so
+            # `tstyles eva -Target defaults` followed by a bundle-less style on
+            # the profile the user is sitting in left eva's GIF drawn behind the
+            # new palette: verbatim the outcome the clear exists to prevent.
+            # `tstyles reset -Target defaults` is the only thing that cleared it,
+            # and that target is documented nowhere the user can read.
+            BeforeEach {
+                $script:managedBg = Join-Path $script:withBgDir 'background.gif'
+                $script:usersBg   = 'C:\Users\someone\Pictures\me.png'
+            }
+
+            It "clears the previous style's image off defaults when the new style ships none" {
+                $s = script:New-Settings -Defaults @{
+                    colorScheme            = 'withbg'
+                    backgroundImage        = $script:managedBg
+                    backgroundImageOpacity = 0.45
+                }
+                Test-ManagedBackgroundPath -Path $script:managedBg |
+                    Should -BeTrue -Because 'the fixture image must be one this tool owns, or nothing here may touch it'
+
+                $out = script:Merge -Settings $s -StyleDir $script:noBgDir
+                (script:GetProfile $out).colorScheme | Should -Be 'nobg'
+                script:BgFieldCount (script:GetDefaults $out) | Should -Be 0 `
+                    -Because 'what the profile SHOWS is what bleeds, wherever the key lives'
+                # Bounded: the background fields, and nothing else on defaults.
+                (script:GetDefaults $out).colorScheme | Should -Be 'withbg' `
+                    -Because 'this apply was not asked to restyle profiles.defaults'
+            }
+
+            It "leaves an image the USER put on defaults exactly where it is" {
+                $s = script:New-Settings -Defaults @{ backgroundImage = $script:usersBg }
+                $out = script:Merge -Settings $s -StyleDir $script:noBgDir
+                (script:GetDefaults $out).backgroundImage | Should -Be $script:usersBg
+            }
+
+            It "leaves the user's defaults image alone while clearing ours off the profile" {
+                # The guard that must not be dropped: both entries carry an
+                # image, only one of them is ours.
+                $s = script:New-Settings -ProfileProps @{ backgroundImage = $script:managedBg } `
+                                         -Defaults     @{ backgroundImage = $script:usersBg }
+                $out = script:Merge -Settings $s -StyleDir $script:noBgDir
+                script:BgFieldCount (script:GetProfile $out) | Should -Be 0
+                (script:GetDefaults $out).backgroundImage | Should -Be $script:usersBg
+            }
+
+            It 'clears both when the profile and defaults each carry one of ours' {
+                $s = script:New-Settings -ProfileProps @{ backgroundImage = $script:managedBg } `
+                                         -Defaults     @{ backgroundImage = $script:managedBg }
+                $out = script:Merge -Settings $s -StyleDir $script:noBgDir
+                script:BgFieldCount (script:GetProfile $out)  | Should -Be 0
+                script:BgFieldCount (script:GetDefaults $out) | Should -Be 0 `
+                    -Because 'stripping only the entry hands the profile straight back to the inherited copy'
+            }
+
+            It 'honours an explicit -BackgroundImage "" against the inherited image' {
+                # The plainest form of the contract: the user typed "no
+                # background" and got "Style applied" in green with the GIF
+                # still on screen.
+                $s = script:New-Settings -Defaults @{ backgroundImage = $script:managedBg }
+                $out = Merge-StyleIntoSettings -Settings $s -StyleDir $script:noBgDir `
+                    -TargetName 'PowerShell' -BackgroundImage '' -BackgroundImageProvided $true
+                script:BgFieldCount (script:GetDefaults $out) | Should -Be 0
+            }
+
+            It 'leaves defaults alone when the new style writes its own image onto the profile' {
+                # Deliberate boundary, not an oversight: a profile-level
+                # backgroundImage shadows defaults, so nothing of the old style
+                # is visible on this profile -- and clearing defaults here would
+                # silently restyle every OTHER profile the user did not name.
+                $s = script:New-Settings -Defaults @{ backgroundImage = $script:managedBg }
+                $out = script:Merge -Settings $s -StyleDir $script:withBgDir
+                (script:GetProfile $out).backgroundImage  | Should -Match 'withbg[\\/]background\.gif$'
+                (script:GetDefaults $out).backgroundImage | Should -Be $script:managedBg
+            }
+
+            It 'still styles profiles.defaults itself when defaults IS the target' {
+                # The inherited lookup must not turn the defaults target into a
+                # reader of its own entry.
+                $s = script:New-Settings -Defaults @{ backgroundImage = $script:managedBg }
+                $out = script:Merge -Settings $s -StyleDir $script:noBgDir -TargetName 'defaults'
+                (script:GetDefaults $out).colorScheme | Should -Be 'nobg'
+                script:BgFieldCount (script:GetDefaults $out) | Should -Be 0
+            }
+
+            It 'is unmoved by a settings.json with no defaults block at all' {
+                $out = script:Merge -Settings (script:New-Settings) -StyleDir $script:noBgDir
+                (script:GetProfile $out).colorScheme | Should -Be 'nobg'
+                $out.profiles.PSObject.Properties.Match('defaults').Count | Should -Be 0 `
+                    -Because 'reading defaults must not create it'
             }
         }
     }

--- a/tests/Delete-Style.Tests.ps1
+++ b/tests/Delete-Style.Tests.ps1
@@ -182,6 +182,27 @@ Describe 'Get-StyleDeletePlan decides before anything is touched' {
             $plan.Children[0].Brightness | Should -Be -20
             $plan.Children[0].Saturation | Should -Be 5
         }
+
+        It 'names a dot-prefixed child too -- the tuner will create one' {
+            # The children come off Get-AvailableStyles, which hid a
+            # dot-prefixed directory on Unix (Get-ChildItem without -Force).
+            # Test-StyleNameValid accepts a leading dot, so `tstyles tune mine`
+            # -> "save as" -> `.wip` makes exactly this style -- and the RED
+            # disclosure line, "'<name>' loses the brightness X and saturation Y
+            # it was tuned by / nothing else records those values", then left it
+            # out of a list the user is entitled to read as complete.
+            foreach ($n in 'keeper', '.wip') {
+                $c = script:New-Style $script:root $n -Tuned
+                [System.IO.File]::WriteAllText((Join-Path $c 'tune.json'),
+                    '{"base":"mine","brightness":30,"saturation":25}')
+            }
+
+            $plan = Get-StyleDeletePlan -Name 'mine'
+            $names = @($plan.Children | ForEach-Object { $_.Name })
+            $names | Should -Contain 'keeper'
+            $names | Should -Contain '.wip' `
+                -Because 'confirming the delete destroys the only record of its deltas'
+        }
     }
 }
 

--- a/tests/Get-AvailableStyles.Tests.ps1
+++ b/tests/Get-AvailableStyles.Tests.ps1
@@ -50,5 +50,66 @@ Describe 'Get-AvailableStyles' {
             $s.FullName | Should -Not -BeNullOrEmpty
             Test-Path -LiteralPath $s.FullName | Should -BeTrue
         }
+
+        Context 'it admits exactly what Get-StyleDir resolves' {
+            # Get-StyleDir is the contract: a name it resolves is one that
+            # applies, tunes and deletes. Two classes of style did all three
+            # while being absent from every enumeration -- so `tstyles list`
+            # showed no row, `tstyles <name>` answered "Unknown command or
+            # style", and the delete consent screen, which names the tuned
+            # children that lose their deltas off this same call, left them out
+            # while destroying their base.
+            #
+            #   .wip    a dot-prefixed name, hidden from Get-ChildItem on Unix
+            #           without -Force. The tuner's own Save-As creates it:
+            #           Test-StyleNameValid accepts a leading dot.
+            #   dev[1]  a name carrying PowerShell wildcard characters, so the
+            #           composed path was a PATTERN to Test-Path and matched
+            #           nothing. Hand-dropped, which README invites.
+            BeforeEach {
+                # [System.IO], not New-Item: the fixture is a pair of names
+                # PowerShell's own path handling is the thing that mangles, and
+                # the test must not depend on how the provider reads a '['.
+                foreach ($n in '.wip', 'dev[1]') {
+                    $d = Join-Path (Join-Path $script:TStylesDataRoot 'styles') $n
+                    [System.IO.Directory]::CreateDirectory($d) | Out-Null
+                    [System.IO.File]::WriteAllText((Join-Path $d 'scheme.json'),
+                        "{`"name`":`"$n`"}", [System.Text.UTF8Encoding]::new($false))
+                }
+            }
+
+            It 'lists a style whose name starts with a dot' {
+                Get-StyleDir -StyleName '.wip' | Should -Not -BeNullOrEmpty `
+                    -Because 'the fixture has to be resolvable or this case measures nothing'
+                @((Get-AvailableStyles).Name) | Should -Contain '.wip'
+            }
+
+            It 'lists a style whose name contains wildcard characters' {
+                Get-StyleDir -StyleName 'dev[1]' | Should -Not -BeNullOrEmpty `
+                    -Because 'the fixture has to be resolvable or this case measures nothing'
+                @((Get-AvailableStyles).Name) | Should -Contain 'dev[1]'
+            }
+
+            It 'names every user directory Get-StyleDir resolves, and no other' {
+                # The invariant rather than two spellings of it. Read off the
+                # filesystem with [System.IO] on purpose: Get-ChildItem is the
+                # half under test, and Test-Path is the half that mangled the
+                # bracketed name.
+                $stylesDir = Join-Path $script:TStylesDataRoot 'styles'
+                $onDisk = @([System.IO.Directory]::GetDirectories($stylesDir) |
+                            ForEach-Object { [System.IO.Path]::GetFileName($_) })
+                @($onDisk).Count | Should -Be 5 `
+                    -Because 'beta, gamma, noscheme, .wip and dev[1] must all be on disk for the loop below to have teeth'
+
+                $listed = @((Get-AvailableStyles).Name)
+                foreach ($n in $onDisk) {
+                    if (Get-StyleDir -StyleName $n) {
+                        $listed | Should -Contain $n -Because "Get-StyleDir resolves '$n', so every listing must show it"
+                    } else {
+                        $listed | Should -Not -Contain $n -Because "nothing resolves '$n', so listing it would be a name that cannot be applied"
+                    }
+                }
+            }
+        }
     }
 }

--- a/tests/Invoke-StylePickerLoop.Tests.ps1
+++ b/tests/Invoke-StylePickerLoop.Tests.ps1
@@ -168,6 +168,35 @@ Describe 'Invoke-StylePickerLoop' {
                 (@(Compare-Object $originalBytes $afterBytes -SyncWindow 0).Count) | Should -Be 0
             }
 
+            It 'restores the byte-exact original settings.json on Esc when the file carries a UTF-8 BOM' {
+                # Same gesture as above against the other encoding a real
+                # settings.json comes in. Windows Terminal writes no BOM, but
+                # Windows PowerShell 5.1's `Out-File -Encoding utf8`, Notepad's
+                # "UTF-8 with BOM" and several editors do, so a hand-edited file
+                # often has one -- and a cancelled pick silently rewrote its
+                # header. The BOM-less fixture above cannot see that: the byte
+                # that goes missing is one it never had.
+                $enc = [System.Text.UTF8Encoding]::new($false)
+                $original = '{"profiles":{"list":[{"name":"Símbolo del sistema","guid":"{abc}"}]}}'
+                [System.IO.File]::WriteAllText($script:settingsPath, $original,
+                    [System.Text.UTF8Encoding]::new($true))
+                # Snapshot exactly as the picker does -- which is where the BOM
+                # is lost, before any key is pressed.
+                $script:originalJson = [System.IO.File]::ReadAllText(
+                    $script:settingsPath, $enc)
+
+                $originalBytes = [System.IO.File]::ReadAllBytes($script:settingsPath)
+                ($originalBytes[0] -eq 0xEF -and $originalBytes[1] -eq 0xBB -and $originalBytes[2] -eq 0xBF) |
+                    Should -BeTrue -Because 'the fixture must really carry a BOM or this case measures nothing'
+
+                $keys = New-KeyStub @([ConsoleKey]::DownArrow, $null, [ConsoleKey]::Escape)
+                $r = Invoke-StylePickerLoop -StyleCount 2 -StartIndex 0 `
+                    -ReadKey $keys -OnPreview $script:onPreview -OnRevert $script:onRevert
+                $r.Outcome | Should -Be 'cancelled'
+                $afterBytes = [System.IO.File]::ReadAllBytes($script:settingsPath)
+                (@(Compare-Object $originalBytes $afterBytes -SyncWindow 0).Count) | Should -Be 0
+            }
+
             It 'persists the chosen style on Enter' {
                 # Down -> Enter (Enter drains the pending preview for index 1 = beta).
                 $keys = New-KeyStub @([ConsoleKey]::DownArrow, [ConsoleKey]::Enter)

--- a/tests/Picker-ShellStateStaging.Tests.ps1
+++ b/tests/Picker-ShellStateStaging.Tests.ps1
@@ -292,7 +292,7 @@ Describe 'the picker puts the terminal back when you cancel' {
         # restore both live in scriptblocks, and the restore has to know whether
         # the picker put a preview on disk at all. A style with no theme.json
         # writes nothing, and restoring "the original" over a file we never
-        # touched drops its BOM and makes Windows Terminal reload for nothing.
+        # touched bumps its mtime and makes Windows Terminal reload for nothing.
         # Matched field by field rather than as one exact literal, so adding a
         # third piece of picker state does not turn this into a red test about
         # nothing.

--- a/tests/Subcommand-Robustness.Tests.ps1
+++ b/tests/Subcommand-Robustness.Tests.ps1
@@ -311,3 +311,49 @@ Describe 'the font download is bounded' {
         }
     }
 }
+
+Describe 'applying by name reaches the styles the tool itself creates' {
+    InModuleScope TerminalStyles {
+        BeforeEach {
+            # Save and restore: this Describe points both roots at a TestDrive,
+            # and the assignment would otherwise persist into the Describes
+            # above and below it.
+            $script:savedData   = $script:TStylesDataRoot
+            $script:savedModule = $script:TStylesModuleRoot
+            $script:TStylesDataRoot   = Join-Path $TestDrive ([guid]::NewGuid().ToString('n'))
+            $script:TStylesModuleRoot = $script:TStylesDataRoot
+            foreach ($n in 'eva', '.wip') {
+                $d = Join-Path (Join-Path $script:TStylesDataRoot 'styles') $n
+                New-Item -ItemType Directory -Path $d -Force | Out-Null
+                [System.IO.File]::WriteAllText((Join-Path $d 'scheme.json'),
+                    "{`"name`":`"$n`"}", [System.Text.UTF8Encoding]::new($false))
+            }
+            Mock Apply-StyleDirect {}
+            Mock Show-TerminalStyleHelp {}
+            Mock Write-Host {}
+        }
+        AfterEach {
+            $script:TStylesDataRoot   = $script:savedData
+            $script:TStylesModuleRoot = $script:savedModule
+        }
+
+        It "applies '.wip' rather than answering 'Unknown command or style'" {
+            # The dispatch matches its argument through Get-AvailableStyles, not
+            # through Get-StyleDir -- so a style the enumeration could not see
+            # was one `tstyles` refused to apply by name, printing the unknown-
+            # command line and the whole help screen for a style its own tuner
+            # had just written (Test-StyleNameValid accepts a leading dot).
+            Invoke-TerminalStyle -Arg '.wip'
+            Should -Invoke Apply-StyleDirect -ParameterFilter { $StyleName -eq '.wip' } -Times 1 -Exactly
+            Should -Not -Invoke Show-TerminalStyleHelp
+        }
+
+        It 'still refuses a name that is no style at all' {
+            # The control: the branch above must not have become "apply
+            # anything", which would take the unknown-command message with it.
+            Invoke-TerminalStyle -Arg 'definitely-not-a-style'
+            Should -Not -Invoke Apply-StyleDirect
+            Should -Invoke Show-TerminalStyleHelp -Times 1
+        }
+    }
+}

--- a/tests/Write-SettingsAtomic.Tests.ps1
+++ b/tests/Write-SettingsAtomic.Tests.ps1
@@ -24,6 +24,40 @@ Describe 'Write-SettingsAtomic' {
             ($bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) | Should -BeFalse
         }
 
+        It 'preserves a UTF-8 BOM the file it replaces already had' {
+            # The snapshot/restore round trip that every Esc path is built on:
+            # [File]::ReadAllText builds its StreamReader with
+            # detectEncodingFromByteOrderMarks:true NO MATTER which encoding it
+            # is handed, so a leading EF BB BF is eaten as an encoding marker
+            # and never reaches the string. Writing UTF8Encoding($false) back
+            # unconditionally therefore rewrote the user's header -- on the
+            # picker's cancel, which tstyles.ps1 and README both call byte-exact,
+            # and on the tuner's. The bytes are the file's property, not the
+            # caller's: Save-SettingsBackup is a Copy-Item for exactly this
+            # reason, and the .bak kept a BOM the live file lost.
+            $f = Join-Path $TestDrive 'settings.json'
+            [System.IO.File]::WriteAllText($f, '{"a":1}', [System.Text.UTF8Encoding]::new($true))
+            $before = [System.IO.File]::ReadAllBytes($f)
+            ($before[0] -eq 0xEF -and $before[1] -eq 0xBB -and $before[2] -eq 0xBF) |
+                Should -BeTrue -Because 'the fixture must really carry a BOM or this case measures nothing'
+
+            $snapshot = [System.IO.File]::ReadAllText($f, [System.Text.UTF8Encoding]::new($false))
+            [int]$snapshot[0] | Should -Be 123 -Because 'the read strips the BOM; that is the half that cannot be fixed at the reader'
+
+            Write-SettingsAtomic -Path $f -Json $snapshot
+
+            $after = [System.IO.File]::ReadAllBytes($f)
+            @(Compare-Object $before $after -SyncWindow 0).Count | Should -Be 0
+        }
+
+        It 'adds no BOM to a file that did not have one' {
+            $f = Join-Path $TestDrive 'settings.json'
+            [System.IO.File]::WriteAllText($f, '{"a":1}', [System.Text.UTF8Encoding]::new($false))
+            Write-SettingsAtomic -Path $f -Json '{"b":2}'
+            $bytes = [System.IO.File]::ReadAllBytes($f)
+            ($bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) | Should -BeFalse
+        }
+
         It 'overwrites an existing file' {
             $f = Join-Path $TestDrive 'settings.json'
             [System.IO.File]::WriteAllText($f, '{"old":true}', [System.Text.UTF8Encoding]::new($false))

--- a/tstyles.ps1
+++ b/tstyles.ps1
@@ -382,11 +382,12 @@ function Test-StyleNameIsSingleSegment {
     Why it is not the stricter rule the tuner applies to names it CREATES: a
     hand-authored style is just a folder the user drops in, and README's
     "Adding your own style" puts no constraint on what it is called. Rejecting
-    spaces or non-ASCII here would strand every such style in a state worse
-    than not existing -- Get-AvailableStyles enumerates directories with no
-    filter, so `My Theme` would still list, still tab-complete, and then fail
-    at every use site (apply, tune, current, the shell-startup re-emit,
-    background inheritance). Reject paths, not names.
+    spaces or non-ASCII here would break every such style at once and say
+    nothing: this gate is what Get-StyleDir resolves through, and
+    Get-AvailableStyles admits exactly what Get-StyleDir resolves -- so `My
+    Theme` would stop applying, stop tuning, stop listing and stop
+    tab-completing, and the folder the user dropped in would simply cease to
+    exist as far as the tool is concerned. Reject paths, not names.
 
     Returns $true/$false; never throws.
     #>
@@ -469,24 +470,38 @@ function Get-StyleDir {
 }
 
 function Get-AvailableStyles {
-    # Returns DirectoryInfo for every styles/<name>/ that has a scheme.json,
+    # Returns DirectoryInfo for every styles/<name>/ that Get-StyleDir resolves,
     # merged from two locations:
     #   1. $DataRoot\styles\<name>\ -- user dir, persistent across updates
     #   2. $ModuleRoot\styles\<name>\ -- bundled, install-managed
     # User-wins on name collision (matches Get-StyleDir's precedence).
     # Sorted alphabetically by name.
+    #
+    # The admission test IS Get-StyleDir, not a second copy of "does this folder
+    # have a scheme.json", because the copy diverged from it in two ways at
+    # once. `Get-ChildItem -Directory` without -Force never returned a
+    # dot-prefixed directory on Unix, and `Test-Path (Join-Path ...)` without
+    # -LiteralPath read `dev[1]/scheme.json` as a wildcard PATTERN, which
+    # matches nothing. Both kinds of style resolved, applied, tuned and deleted
+    # perfectly while being absent from every enumeration: no row in `tstyles
+    # list`, no tab-completion, never picked by `random`, and `tstyles .wip`
+    # answered "Unknown command or style" for a style the tuner had just
+    # created (the dispatch matches the argument through here, not through
+    # Get-StyleDir). Worse, the delete consent screen names the tuned children
+    # that lose their brightness/saturation off this same call, so it destroyed
+    # deltas it had just told the user it would not touch.
     $userStylesDir    = Join-Path $script:TStylesDataRoot   'styles'
     $bundledStylesDir = Join-Path $script:TStylesModuleRoot 'styles'
 
     $user = if (Test-Path -LiteralPath $userStylesDir) {
-        @(Get-ChildItem -LiteralPath $userStylesDir -Directory | Where-Object {
-            Test-Path (Join-Path $_.FullName 'scheme.json')
+        @(Get-ChildItem -LiteralPath $userStylesDir -Directory -Force | Where-Object {
+            Get-StyleDir -StyleName $_.Name
         })
     } else { @() }
 
     $bundled = if (Test-Path -LiteralPath $bundledStylesDir) {
-        @(Get-ChildItem -LiteralPath $bundledStylesDir -Directory | Where-Object {
-            Test-Path (Join-Path $_.FullName 'scheme.json')
+        @(Get-ChildItem -LiteralPath $bundledStylesDir -Directory -Force | Where-Object {
+            Get-StyleDir -StyleName $_.Name
         })
     } else { @() }
 
@@ -800,11 +815,12 @@ function Invoke-TerminalStyle {
     # Guarded on having written, because a picker session can now legitimately
     # write NOTHING -- open it on a style with no theme.json and press Esc and
     # there is no preview on disk to undo. Restoring anyway would rewrite the
-    # file with the same characters, which is not free: Write-SettingsAtomic
-    # emits UTF-8 with no BOM (so a BOM the user had is gone), it bumps the
-    # mtime, and Windows Terminal watches the file and reloads on the change.
-    # "Nothing was written to settings.json" has to mean the file was not
-    # touched, or it is the same claim this whole path was fixed for.
+    # file with the same characters, which is not free: it bumps the mtime, and
+    # Windows Terminal watches the file and reloads on the change. "Nothing was
+    # written to settings.json" has to mean the file was not touched, or it is
+    # the same claim this whole path was fixed for. (The bytes themselves do
+    # survive a restore now -- Write-SettingsAtomic keeps the BOM the live file
+    # had, which it used to drop on every write.)
     $restoreOriginalSettings = {
         if ($pickerState.SettingsWritten) {
             & $writeSettings $originalJson


### PR DESCRIPTION
Three findings from the audit ledger (7, 24, 26). They share a theme — something decided from a narrower view than the thing it was deciding about — but not a mechanism, so they are fixed separately.

## 26 — every write dropped a BOM the file already had

The picker documents its Esc revert as byte-exact. It is not: `Write-SettingsAtomic` emits UTF-8 with no BOM unconditionally.

```
          main    fixed
before:   BOM     BOM
after:    no BOM  BOM
```

The BOM is already gone by the picker's **first preview write**, so patching only the revert would still lose it after a crash mid-preview and after Enter. Fixed at the **single writer**, which also covers apply, reset, the tuner and the font writer — the encoding is a property of the user's file, not of whichever command touched it.

## 7 — styles the tuner creates were invisible to every listing

`Get-AvailableStyles` enumerated with a pattern that skips dot-prefixed directories and treats `[`/`]` as wildcards, while `Get-StyleDir` resolves both. So a style named `.wip` or `dev[1]` could be applied by name and tuned — but never appeared in `tstyles list`, never in the picker, and **never in the "these go with it" list the delete prompt prints before erasing it**.

Not the four-token `-Force`/`-LiteralPath` patch the reproduction suggested: that leaves the same rule in two places, one token from drifting again. `Get-StyleDir` is now the admission test, which removes the second decider and closes a third divergence for free — a directory name the resolver *refuses* can no longer be listed either, the "worse than not existing" state the resolver's own docstring exists to prevent.

```
[-] lists a style whose name starts with a dot            (against main)
[-] lists a style whose name contains wildcard characters
[-] names every user directory Get-StyleDir resolves, and no other
[-] names a dot-prefixed child too -- the tuner will create one
[-] applies '.wip' rather than answering 'Unknown command or style'
```

## 24 — a `profiles.defaults` background bled into the next style

The clear-what-we-wrote rule asked only about the key on the *target entry*, and an image inherited from `defaults` is not on it — so applying a style that ships no background left the old one showing. The question is now asked of the background the profile actually **shows**, through the resolver that already answers "what entry does this target resolve to" for all four shapes `profiles` can take.

## One judgement call worth a reviewer's eye

**The 24 fix can change profiles the user did not name.** When the incoming style ships no background and `profiles.defaults` carries one of ours, those fields are removed from `defaults` — so every other profile inheriting it loses that image too.

I believe that is right: the policy is "one we wrote for the previously applied style gets cleared", and the image on `defaults` is exactly that. The alternative — a per-profile "no image" override — needs Windows Terminal semantics neither I nor the implementer can verify from macOS. But it is the one place where the smallest correct fix has a blast radius wider than the named target, and `Merge-StyleIntoSettings` returns settings rather than a report, so nothing is *said* about it. Flagging rather than burying.

## Deliberately not done, and why

- **Did not reject a leading dot in `Test-StyleNameValid`.** Fixing the enumeration keeps such styles working; rejecting the name would strand every `.wip` already on disk. If the tuner should stop creating them, that is its own one-clause decision.
- **Did not extend `reset` to clear an inherited managed background.** `tstyles reset` on a named profile still leaves a managed image on `defaults`. `tstyles reset -Target defaults` does clear it. Different remit — worth its own finding.
- **`defaults` is undocumented.** The reproduction's claim that "the user has no command that removes it" is false, but `defaults` appears nowhere in README, `docs/` or `tstyles help`, so the escape hatch cannot be found from the tool's own documentation. Documentation scope.

## Verification

Binding proven per finding against reverted source. The BOM table above is my own run against both trees. Full suite: 1721 passed, 11 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4UptB5S567PxKmMdyH8T1
