### PR TITLE
fix(styles): the leak check whitelisted the leak, and gitbash used it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **the leak check whitelisted the leak, so one style went on overwriting the user's own shell variables.** 0.8.22 renamed the runtime's `TS_LOADED` and `TS_SHELL` because bare names in the user's shell are the thing this project forbids -- and both style leak checks excused `^(TS_|_ts_)`, the very prefix that release had just declared a leak. `gitbash/prompt.sh` accordingly kept defining `TS_GIT_OPEN` and `TS_GIT_CLOSE` at top level, replacing anything the user had under those names on every new shell, while the check reported green.
+
+  The names are now `_ts_git_open` and `_ts_git_close` like everything else, and the whitelist is `_ts_` only. Measured with the old style restored: the tightened check fails twice, naming `TS_GIT_CLOSE, TS_GIT_OPEN` from both the static lint and the real-zsh measurement, where the old whitelist passed 150 of 150 with the same leak present.
+
+  That is the last of the twenty-six defects the audit reproduced against the real code.
+
+### Fixed
+
 - **every write to `settings.json` dropped a byte-order mark the file already had.** The picker documents its Esc revert as putting the file back byte-exactly, and it did not: `Write-SettingsAtomic` emits UTF-8 with no BOM unconditionally. The BOM is already gone by the picker's FIRST preview write, so repairing only the revert would have left it lost after a crash mid-preview and after Enter. Fixed in the single writer instead, which also covers apply, reset, the tuner and the font writer -- the encoding is a property of the user's file, not of the command that happened to touch it. Measured: a `settings.json` opening `EF BB BF` came back without it on every path, and now comes back with it.
 
 - **styles the tuner itself creates were invisible to every listing, including the delete consent listing that is supposed to name what goes.** `Get-AvailableStyles` enumerated with a pattern that skips a dot-prefixed directory and treats `[` and `]` as wildcards, while `Get-StyleDir` resolves both -- so a style named `.wip` or `dev[1]` could be applied by name and tuned, but never appeared in `tstyles list`, never in the picker, and never in the "these go with it" list the delete prompt prints before erasing it. The enumeration now admits exactly what `Get-StyleDir` resolves, rather than carrying a second, narrower answer to the same question. That also closes a third divergence: a directory name the resolver refuses can no longer be listed either, which is the "worse than not existing" state the resolver's own docstring exists to prevent.

--- a/shell/tstyles.sh
+++ b/shell/tstyles.sh
@@ -154,7 +154,7 @@ ts_git_branch() {
     # Defaulted anyway: a template carrying {GITBRANCH} reaches this function
     # from whatever style is staged, and an uncolored branch is a better answer
     # than an error inside the prompt of every command.
-    printf ' %s(%s)%s' "${TS_GIT_OPEN-}" "$_ts_b" "${TS_GIT_CLOSE-}"
+    printf ' %s(%s)%s' "${_ts_git_open-}" "$_ts_b" "${_ts_git_close-}"
 }
 
 ts_prompt_apply() {

--- a/styles/gitbash/prompt.sh
+++ b/styles/gitbash/prompt.sh
@@ -22,7 +22,11 @@ _ts_pYellow=$(ts_c '155;150;29')
 ts_title 'GITBASH // MINGW64'
 
 # Colors for the " (branch)" segment ts_git_branch appends.
-TS_GIT_OPEN=$(ts_cs '187;0;187')   # same magenta as pMagenta, but substitution-safe
-TS_GIT_CLOSE=$(ts_xs)
+# _ts_-prefixed like everything else this file defines. These were the last two
+# bare names any style put in the user's shell -- 0.8.22 renamed the runtime's
+# own TS_LOADED and TS_SHELL for exactly this reason and these were missed,
+# because both leak checks whitelist the TS_ prefix that release declared a leak.
+_ts_git_open=$(ts_cs '187;0;187')   # same magenta as pMagenta, but substitution-safe
+_ts_git_close=$(ts_xs)
 
 ts_prompt_apply "$(ts_prompt_expand "${_ts_pGreen}{USER}@{HOST}${_ts_pX} ${_ts_pYellow}MINGW64${_ts_pX} ${_ts_pCyan}{CWD}${_ts_pX}{GITBRANCH}{NL}${_ts_pGray}\$${_ts_pX} ")"

--- a/tests/Shell-Prompt.Tests.ps1
+++ b/tests/Shell-Prompt.Tests.ps1
@@ -182,6 +182,11 @@ Describe 'a style prompt does not clobber the user''s shell variables' {
     # user had by those names. $X and $D are not exotic choices for a person's
     # own scratch variables.
     #
+    # _ts_ ONLY. The whitelist used to read ^(TS_|_ts_), which excused the very
+    # prefix 0.8.22 declared a leak when it renamed the runtime's TS_LOADED and
+    # TS_SHELL -- so gitbash went on defining TS_GIT_OPEN and TS_GIT_CLOSE in
+    # the user's shell and this check reported green. A leak check that
+    # whitelists the leak is the shape CLAUDE.md warns about.
     # Everything is prefixed _ts_ now. Verified in a real interactive zsh: a
     # .zshrc setting X and D keeps both after the style loads.
     BeforeDiscovery {
@@ -204,7 +209,7 @@ Describe 'a style prompt does not clobber the user''s shell variables' {
         # CHANGELOG said the defect was closed.
         $bare = @([regex]::Matches($text, '(?m)(?:^|[\s;&|(])([A-Za-z_][A-Za-z0-9_]*)=') |
             ForEach-Object { $_.Groups[1].Value } |
-            Where-Object { $_ -notmatch '^(TS_|_ts_)' } |
+            Where-Object { $_ -notmatch '^_ts_' } |
             Sort-Object -Unique)
 
         $bare | Should -BeNullOrEmpty `
@@ -256,7 +261,7 @@ Describe 'a style leaks nothing into the user shell -- measured, not linted' {
         [System.IO.File]::WriteAllText($sf, $script, [System.Text.UTF8Encoding]::new($false))
 
         $out = & zsh -f $sf 2>$null
-        $leaked = @($out | Where-Object { $_ -and $_ -notmatch '^(TS_|_ts_|ts_before$|ts_after$)' } |
+        $leaked = @($out | Where-Object { $_ -and $_ -notmatch '^(_ts_|ts_before$|ts_after$)' } |
                    Sort-Object -Unique)
 
         $leaked -join ', ' | Should -BeNullOrEmpty `

--- a/tests/Shell-Runtime-Escaping.Tests.ps1
+++ b/tests/Shell-Runtime-Escaping.Tests.ps1
@@ -85,7 +85,7 @@ Describe 'ts_git_branch survives a hostile branch name' {
         $out = script:Invoke-Shell -Shell 'zsh' -Script @"
 cd '$repo'
 . '$($script:runtime)' 2>/dev/null
-TS_GIT_OPEN=''; TS_GIT_CLOSE=''
+_ts_git_open=''; _ts_git_close=''
 setopt PROMPT_SUBST
 PROMPT="`$(ts_git_branch)"
 print -rP "[`$PROMPT]"
@@ -100,7 +100,7 @@ print -rP "[`$PROMPT]"
         $out = script:Invoke-Shell -Shell 'zsh' -Script @"
 cd '$repo'
 . '$($script:runtime)' 2>/dev/null
-TS_GIT_OPEN=''; TS_GIT_CLOSE=''
+_ts_git_open=''; _ts_git_close=''
 setopt PROMPT_SUBST
 PROMPT="`$(ts_git_branch) END"
 print -rP "[`$PROMPT]"
@@ -115,7 +115,7 @@ print -rP "[`$PROMPT]"
         $out = script:Invoke-Shell -Shell 'bash' -Script @"
 cd '$repo'
 . '$($script:runtime)' 2>/dev/null
-TS_GIT_OPEN=''; TS_GIT_CLOSE=''
+_ts_git_open=''; _ts_git_close=''
 ts_git_branch
 "@
         $out | Should -Match '\(100%done\)'
@@ -151,8 +151,8 @@ ts_cs '187;0;187'
     It 'gitbash uses the substitution-safe helper for its branch colours' {
         $p = Join-Path (Join-Path (Split-Path $PSScriptRoot -Parent) 'styles/gitbash') 'prompt.sh'
         $src = [System.IO.File]::ReadAllText($p, [System.Text.UTF8Encoding]::new($false))
-        $src | Should -Match 'TS_GIT_OPEN=\$\(ts_cs'
-        $src | Should -Match 'TS_GIT_CLOSE=\$\(ts_xs\)'
+        $src | Should -Match '_ts_git_open=\$\(ts_cs'
+        $src | Should -Match '_ts_git_close=\$\(ts_xs\)'
     }
 }
 

--- a/tests/Shell-Runtime-Nounset.Tests.ps1
+++ b/tests/Shell-Runtime-Nounset.Tests.ps1
@@ -210,7 +210,7 @@ printf 'REACHED-END\n'
 Describe 'a style prompt loads under set -u too' {
     # styles/<name>/prompt.sh is sourced by the same runtime, in the same shell,
     # with the same options in force. None of the sixteen reads an ambient
-    # variable today -- gitbash assigns TS_GIT_OPEN/TS_GIT_CLOSE itself before
+    # variable today -- gitbash assigns _ts_git_open/_ts_git_close itself before
     # ts_git_branch can run -- and this is what keeps the next one from
     # introducing one.
     It '<_> sources cleanly in bash' -ForEach $script:StyleNames -Skip:$script:NoBash {
@@ -237,7 +237,7 @@ printf 'STYLE-OK\n'
         $r.StdOut | Should -Match 'STYLE-OK'
     }
 
-    It 'ts_git_branch renders with TS_GIT_OPEN and TS_GIT_CLOSE never assigned' -Skip:$script:NoBash {
+    It 'ts_git_branch renders with _ts_git_open and _ts_git_close never assigned' -Skip:$script:NoBash {
         # Only gitbash's prompt.sh sets those two, so any other style whose
         # template ever carries {GITBRANCH} reaches the printf with both unset.
         # Under nounset that is an error inside the prompt of every command.


### PR DESCRIPTION
The last of the twenty-six defects the audit reproduced (finding 23).

## The defect

0.8.22 renamed the runtime's `TS_LOADED` and `TS_SHELL` because bare names in the user's shell are the thing this project forbids. Its CHANGELOG entry says so in as many words.

**Both style leak checks excused `^(TS_|_ts_)`** — the very prefix that release had just declared a leak. So `gitbash/prompt.sh` kept defining:

```sh
TS_GIT_OPEN=$(ts_cs '187;0;187')
TS_GIT_CLOSE=$(ts_xs)
```

at top level, replacing anything the user had under those names on every new shell — while the check reported green.

## Binding, measured both ways

With the old style restored:

```
new check : 148 passed, 2 FAILED
  [-] gitbash/prompt.sh assigns only namespaced names at top level
      "...gitbash would overwrite the user's own TS_GIT_CLOSE, TS_GIT_OPEN
       on every new shell, but got @('TS_GIT_CLOSE', 'TS_GIT_OPEN')."
  [-] gitbash defines no bare name in a real zsh
      "...sourcing gitbash/prompt.sh replaced the user's own
       TS_GIT_CLOSE, TS_GIT_OPEN"

old check : 150 passed, 0 failed      <- green, with the same leak present
```

Both halves catch it now — the static lint *and* the real-zsh measurement that 0.8.22 added precisely because a regex could be stepped around.

## The fix

`_ts_git_open` / `_ts_git_close`, in the style, in `shell/tstyles.sh` which reads them for `{GITBRANCH}`, and in the three test files that pinned the old names. The whitelist is `_ts_` only.

`TSTYLES_DATA` is untouched and stays whitelisted elsewhere — the runtime reads it before deriving a default and the suite uses that seam to point a shell at a scratch data root, so it is a contract rather than a leak, exactly as 0.8.22 reasoned.

Full suite: 1757 passed, 11 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4UptB5S567PxKmMdyH8T1
